### PR TITLE
Fix Windows build

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -105,11 +105,11 @@ pub fn config_dir() -> Result<PathBuf, String> {
 pub fn config_dir() -> Result<PathBuf, String> {
     env::var("APPDATA")
         .map(From::from)
-        .ok_or_else(|_| {
+        .or_else(|_| {
             env::home_dir()
                 .ok_or("Home dir not present".to_owned())
                 .map(From::from)
-                .map(|mut x: PathBuf| { x.push("AppData\\Roaming"); x})
+                .map(|mut x: PathBuf| { x.push("AppData\\Roaming"); x })
         })
 }
 


### PR DESCRIPTION
The Windows `config_dir` function is now similar to the Linux one. It compiles, too!