### PR TITLE
CLI: fall back to noninteractive-with-prompt

### DIFF
--- a/src/bin/rink.rs
+++ b/src/bin/rink.rs
@@ -52,6 +52,18 @@ fn main_interactive() {
     use std::rc::Rc;
     use std::cell::RefCell;
 
+    let mut rl = match Reader::new("rink") {
+        Err(_) => {
+            // If we can't initialize linefeed on this terminal for some reason,
+            // e.g. it being a pipe instead of a tty, use the noninteractive version
+            // with prompt instead.
+            let stdin_handle = stdin();
+            return main_noninteractive(stdin_handle.lock(), true);
+        },
+        Ok(rl) => rl
+    };
+    rl.set_prompt("> ");
+
     struct RinkCompleter(Rc<RefCell<Context>>);
 
     impl<Term: Terminal> Completer<Term> for RinkCompleter {
@@ -203,8 +215,6 @@ fn main_interactive() {
     };
     let ctx = Rc::new(RefCell::new(ctx));
     let completer = RinkCompleter(ctx.clone());
-    let mut rl = Reader::new("rink").unwrap();
-    rl.set_prompt("> ");
     rl.set_completer(Rc::new(completer));
 
     let mut hpath = rink::config_dir();

--- a/src/date.rs
+++ b/src/date.rs
@@ -383,7 +383,7 @@ pub fn now() -> DateTime<FixedOffset> {
     UTC::now().with_timezone(&FixedOffset::east(0))
 }
 
-pub fn parse_datepattern<I>(mut iter: &mut Peekable<I>)
+pub fn parse_datepattern<I>(iter: &mut Peekable<I>)
                             -> Result<Vec<DatePattern>, String> where I: Iterator<Item=char> {
     let mut out = vec![];
     while iter.peek().is_some() {

--- a/src/gnu_units.rs
+++ b/src/gnu_units.rs
@@ -204,7 +204,7 @@ impl<'a> Iterator for TokenIterator<'a> {
 
 pub type Iter<'a> = Peekable<TokenIterator<'a>>;
 
-fn parse_term(mut iter: &mut Iter) -> Expr {
+fn parse_term(iter: &mut Iter) -> Expr {
     match iter.next().unwrap() {
         Token::Ident(name) => match iter.peek().cloned().unwrap() {
             Token::Ident(ref s) if s == "of" => {
@@ -233,7 +233,7 @@ fn parse_term(mut iter: &mut Iter) -> Expr {
     }
 }
 
-fn parse_pow(mut iter: &mut Iter) -> Expr {
+fn parse_pow(iter: &mut Iter) -> Expr {
     let left = parse_term(iter);
     match *iter.peek().unwrap() {
         Token::Caret => {
@@ -250,7 +250,7 @@ fn parse_pow(mut iter: &mut Iter) -> Expr {
     }
 }
 
-fn parse_mul(mut iter: &mut Iter) -> Expr {
+fn parse_mul(iter: &mut Iter) -> Expr {
     let mut terms = vec![parse_pow(iter)];
     loop { match iter.peek().cloned().unwrap() {
         Token::Slash | Token::Plus | Token::Dash | Token::RPar | Token::Newline | Token::Eof =>
@@ -267,7 +267,7 @@ fn parse_mul(mut iter: &mut Iter) -> Expr {
     }
 }
 
-fn parse_div(mut iter: &mut Iter) -> Expr {
+fn parse_div(iter: &mut Iter) -> Expr {
     let mut left = parse_mul(iter);
     loop { match *iter.peek().unwrap() {
         Token::Slash => {
@@ -280,7 +280,7 @@ fn parse_div(mut iter: &mut Iter) -> Expr {
     left
 }
 
-fn parse_add(mut iter: &mut Iter) -> Expr {
+fn parse_add(iter: &mut Iter) -> Expr {
     let left = parse_div(iter);
     match *iter.peek().unwrap() {
         Token::Plus => {
@@ -297,11 +297,11 @@ fn parse_add(mut iter: &mut Iter) -> Expr {
     }
 }
 
-pub fn parse_expr(mut iter: &mut Iter) -> Expr {
+pub fn parse_expr(iter: &mut Iter) -> Expr {
     parse_add(iter)
 }
 
-pub fn parse(mut iter: &mut Iter) -> Defs {
+pub fn parse(iter: &mut Iter) -> Defs {
     let mut map = vec![];
     let mut line = 1;
     let mut doc = None;
@@ -535,7 +535,7 @@ pub fn parse(mut iter: &mut Iter) -> Defs {
     }
 }
 
-pub fn tokens(mut iter: &mut Iter) -> Vec<Token> {
+pub fn tokens(iter: &mut Iter) -> Vec<Token> {
     let mut out = vec![];
     loop {
         match iter.next().unwrap() {

--- a/src/load.rs
+++ b/src/load.rs
@@ -324,7 +324,7 @@ impl Context {
                         let unit = (&input / &output)
                             .expect("Non-zero property")
                             .unit;
-                        let mut existing = prev.entry(unit).or_insert(BTreeSet::new());
+                        let existing = prev.entry(unit).or_insert(BTreeSet::new());
                         for conflict in existing.intersection(&unique) {
                             println!(
                                 "Warning: conflicting \

--- a/src/text_query.rs
+++ b/src/text_query.rs
@@ -484,7 +484,7 @@ fn is_attr(name: &str) -> Option<&'static str> {
     }
 }
 
-fn parse_term(mut iter: &mut Iter) -> Expr {
+fn parse_term(iter: &mut Iter) -> Expr {
     match iter.next().unwrap() {
         Token::Ident(ref name) if is_func(name) => {
             match iter.peek().cloned().unwrap() {
@@ -567,7 +567,7 @@ fn parse_term(mut iter: &mut Iter) -> Expr {
     }
 }
 
-fn parse_suffix(mut iter: &mut Iter) -> Expr {
+fn parse_suffix(iter: &mut Iter) -> Expr {
     let left = parse_term(iter);
     match *iter.peek().unwrap() {
         Token::Percent => {
@@ -582,7 +582,7 @@ fn parse_suffix(mut iter: &mut Iter) -> Expr {
     }
 }
 
-fn parse_pow(mut iter: &mut Iter) -> Expr {
+fn parse_pow(iter: &mut Iter) -> Expr {
     let left = parse_suffix(iter);
     match *iter.peek().unwrap() {
         Token::Caret => {
@@ -594,7 +594,7 @@ fn parse_pow(mut iter: &mut Iter) -> Expr {
     }
 }
 
-fn parse_frac(mut iter: &mut Iter) -> Expr {
+fn parse_frac(iter: &mut Iter) -> Expr {
     let left = parse_pow(iter);
     match *iter.peek().unwrap() {
         Token::Pipe => {
@@ -606,7 +606,7 @@ fn parse_frac(mut iter: &mut Iter) -> Expr {
     }
 }
 
-fn parse_juxt(mut iter: &mut Iter) -> Expr {
+fn parse_juxt(iter: &mut Iter) -> Expr {
     let mut terms = vec![parse_frac(iter)];
     loop { match iter.peek().cloned().unwrap() {
         Token::Asterisk | Token::Slash | Token::Comma | Token::Equals |
@@ -646,7 +646,7 @@ fn parse_juxt(mut iter: &mut Iter) -> Expr {
     }
 }
 
-fn parse_div(mut iter: &mut Iter) -> Expr {
+fn parse_div(iter: &mut Iter) -> Expr {
     let mut terms = vec![parse_juxt(iter)];
     loop { match iter.peek().cloned().unwrap() {
         Token::Slash => {
@@ -671,7 +671,7 @@ fn parse_div(mut iter: &mut Iter) -> Expr {
     }
 }
 
-fn parse_add(mut iter: &mut Iter) -> Expr {
+fn parse_add(iter: &mut Iter) -> Expr {
     let mut left = parse_div(iter);
     loop { match *iter.peek().unwrap() {
         Token::Plus => {
@@ -688,7 +688,7 @@ fn parse_add(mut iter: &mut Iter) -> Expr {
     }}
 }
 
-fn parse_eq(mut iter: &mut Iter) -> Expr {
+fn parse_eq(iter: &mut Iter) -> Expr {
     let left = parse_add(iter);
     match iter.peek().cloned().unwrap() {
         Token::Equals => {
@@ -704,7 +704,7 @@ pub fn parse_expr(iter: &mut Iter) -> Expr {
     parse_eq(iter)
 }
 
-pub fn parse_unitlist(mut iter: &mut Iter) -> Option<Vec<String>> {
+pub fn parse_unitlist(iter: &mut Iter) -> Option<Vec<String>> {
     let mut expecting_term = true;
     let mut res = vec![];
     loop { match iter.next().unwrap() {
@@ -725,7 +725,7 @@ pub fn parse_unitlist(mut iter: &mut Iter) -> Option<Vec<String>> {
     }
 }
 
-pub fn parse_offset(mut iter: &mut Iter) -> Option<i64> {
+pub fn parse_offset(iter: &mut Iter) -> Option<i64> {
     use std::str::FromStr;
 
     let sign = match iter.next().unwrap() {
@@ -748,7 +748,7 @@ pub fn parse_offset(mut iter: &mut Iter) -> Option<i64> {
     Some(sign * (i64::from_str(&*hour).unwrap() * 3600 + i64::from_str(&*min).unwrap() * 60))
 }
 
-pub fn parse_query(mut iter: &mut Iter) -> Query {
+pub fn parse_query(iter: &mut Iter) -> Query {
     match iter.peek().cloned() {
         Some(Token::Ident(ref s)) if s == "factorize" => {
             iter.next();


### PR DESCRIPTION
Sometimes it's useful to delegate REPL input handling to another
piece of software, e.g. SublimeREPL, but behave in the same way,
e.g. showing the prompt, in all other ways.