### PR TITLE
Update linefeed 0.4.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ chrono = "0.2.25"
 strsim = "0.5.1"
 chrono-tz = "0.2.2"
 chrono-humanize = { version = "0.0.6", optional = true }
-linefeed = { version = "0.2.6", optional = true }
+linefeed = { version = "0.4.0", optional = true }
 hyper = { version = "0.10.10", optional = true }
 hyper-native-tls = { version = "0.2.2", optional = true }
 libc = { version = "0.2.14", optional = true }


### PR DESCRIPTION
linefeed 0.2.6 doesn't build on FreeBSD.