### PR TITLE
Update hyper-native-tls dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ chrono-tz = "0.2.2"
 chrono-humanize = { version = "0.0.6", optional = true }
 linefeed = { version = "0.4.0", optional = true }
 hyper = { version = "0.10.10", optional = true }
-hyper-native-tls = { version = "0.2.2", optional = true }
+hyper-native-tls = { version = "0.3", optional = true }
 libc = { version = "0.2.14", optional = true }
 ipc-channel = { version = "0.5.1", optional = true }
 xml-rs = { version = "0.3.4", optional = true }


### PR DESCRIPTION
The current version of Rink cannot be built when running the most recent version of OpenSSL (1.1.1) when using the `currency` feature. That feature depends on a version of `hyper-native-tls` that cannot be be built using the above OpenSSL version, at least not on my Arch installation.