### PR TITLE
Handle command line arguments, addresses #29

### DIFF
--- a/src/bin/rink.rs
+++ b/src/bin/rink.rs
@@ -278,8 +278,28 @@ fn main_interactive() {
     main_noninteractive(stdin.lock(), true);
 }
 
+fn usage() {
+    let name = env!("CARGO_PKG_NAME");
+    println!(
+        "{} {}\n{}\n{}\n\n\
+        USAGE:\n    {0} [input file]\n\n\
+        FLAGS:\n    -h, --help      Prints help information\n\n\
+        ARGS:\n    <input file>    Evaluate queries from this file",
+        name,
+        env!("CARGO_PKG_VERSION"),
+        env!("CARGO_PKG_AUTHORS"),
+        env!("CARGO_PKG_DESCRIPTION"),
+    );
+}
+
 fn main() {
     use std::env::args;
+
+    let help = args().any(|arg| arg == "-h" || arg == "--help");
+    if args().len() > 2 || help {
+        usage();
+        std::process::exit(if help { 0 } else { 1 });
+    }
 
     // Specify the file to parse commands from as a shell argument
     // i.e. "rink <file>"

--- a/src/bin/rink.rs
+++ b/src/bin/rink.rs
@@ -279,26 +279,39 @@ fn main_interactive() {
 }
 
 fn usage() {
-    let name = env!("CARGO_PKG_NAME");
     println!(
         "{} {}\n{}\n{}\n\n\
         USAGE:\n    {0} [input file]\n\n\
-        FLAGS:\n    -h, --help      Prints help information\n\n\
+        FLAGS:\n    -h, --help      Prints help information\n    \
+        -V, --version   Prints version information\n\n\
         ARGS:\n    <input file>    Evaluate queries from this file",
-        name,
+        env!("CARGO_PKG_NAME"),
         env!("CARGO_PKG_VERSION"),
         env!("CARGO_PKG_AUTHORS"),
         env!("CARGO_PKG_DESCRIPTION"),
     );
 }
 
+fn version() {
+    println!("{} {}", env!("CARGO_PKG_NAME"), env!("CARGO_PKG_VERSION"));
+}
+
 fn main() {
     use std::env::args;
 
-    let help = args().any(|arg| arg == "-h" || arg == "--help");
-    if args().len() > 2 || help {
+    if args().any(|arg| arg == "-h" || arg == "--help") {
         usage();
-        std::process::exit(if help { 0 } else { 1 });
+        return;
+    }
+
+    if args().any(|arg| arg == "-V" || arg == "--version") {
+        version();
+        return;
+    }
+
+    if args().len() > 2 {
+        usage();
+        std::process::exit(1);
     }
 
     // Specify the file to parse commands from as a shell argument

--- a/src/bin/rink.rs
+++ b/src/bin/rink.rs
@@ -325,7 +325,13 @@ fn main() {
                     let stdin_handle = stdin();
                     main_noninteractive(stdin_handle.lock(), false);
                 },
-                _ => main_noninteractive(BufReader::new(File::open(name).unwrap()), false)
+                _ => {
+                    let file = File::open(&name).unwrap_or_else(|e| {
+                        eprintln!("Could not open input file '{}': {}", name, e);
+                        std::process::exit(1);
+                    });
+                    main_noninteractive(BufReader::new(file), false);
+                }
             };
         },
         // else call the interactive version


### PR DESCRIPTION
Print a usage message when Rink is called with `-h` and `--help`.  Print the Rink version when called with `-V` or `--version`.  Printing the project URL in either of these cases, as suggested in #29, seems very unusual to me, so I left it out.

While I was at it, I also replaced the call to `.unwrap()` on the result of `File::open` with printing a more readable error message and exiting.