### PR TITLE
Use `slice::iter` instead of `into_iter` to avoid future breakage

### DIFF
--- a/src/eval.rs
+++ b/src/eval.rs
@@ -569,7 +569,7 @@ impl Context {
                 value = rem;
             }
         }
-        Ok(list.into_iter().zip(out.into_iter()).map(|(name, value)| {
+        Ok(list.iter().zip(out.into_iter()).map(|(name, value)| {
             let pretty = Number {
                 value: value,
                 unit: Number::one_unit(Dim::new(name)).unit

--- a/src/factorize.rs
+++ b/src/factorize.rs
@@ -38,7 +38,7 @@ pub fn fast_decompose(value: &Number, quantities: &BTreeMap<Unit, String>) -> Un
             value: Num::one(),
             unit: unit.clone(),
         };
-        for &i in [-1, 1, 2].into_iter() {
+        for &i in [-1, 1, 2].iter() {
             let res = (value / &num.powi(i)).unwrap();
             let score = res.complexity_score();
             let better = best.as_ref().map(|&(_, _, _, current)| score < current).unwrap_or(true);


### PR DESCRIPTION
`an_array.into_iter()` currently just works because of the autoref
feature, which then calls `<[T] as IntoIterator>::into_iter`. But
in the future, arrays will implement `IntoIterator`, too. In order
to avoid problems in the future, the call is replaced by `iter()`
which is shorter and more explicit.

A crater run showed that your crate is affected by a potential future 
change. See https://github.com/rust-lang/rust/pull/65819 for more information.
