### PR TITLE
Replace hyper with reqwest

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ keywords = ["unit", "math", "conversion", "cli", "tool"]
 default = ["linefeed", "chrono-humanize", "gpl", "currency"]
 sandbox = ["libc", "ipc-channel"]
 gpl = []
-currency = ["hyper", "hyper-native-tls", "xml-rs", "json"]
+currency = ["reqwest", "xml-rs", "json"]
 nightly = ["serde", "serde_derive"]
 
 [dependencies]
@@ -23,8 +23,7 @@ strsim = "0.5.1"
 chrono-tz = "0.2.2"
 chrono-humanize = { version = "0.0.6", optional = true }
 linefeed = { version = "0.4.0", optional = true }
-hyper = { version = "0.10.10", optional = true }
-hyper-native-tls = { version = "0.3", optional = true }
+reqwest = { version = "0.9.2", optional = true }
 libc = { version = "0.2.14", optional = true }
 ipc-channel = { version = "0.5.1", optional = true }
 xml-rs = { version = "0.3.4", optional = true }


### PR DESCRIPTION
The latest version of hyper makes it much harder to use HTTPS, and reqwest didn't exist when I wrote this code, so switching over makes sense.

Code coverage check is failing because I'm editing code that cannot be unit tested, and it's not clear to me how to resolve that without introducing random failures into the test runner.