### PR TITLE
add some steroid hormones to definitions.units

### DIFF
--- a/definitions.units
+++ b/definitions.units
@@ -2531,6 +2531,12 @@ litre                   liter
 dioptre                 diopter
 aluminium               aluminum
 sulphur                 sulfur
+androstenolone          dehydroepiandrosterone
+androstanolone          dihydrotestosterone
+oestrone                estrone
+oestradiol              estradiol
+oestriol                estriol
+oestetrol               estetrol
 
 #
 # Units derived the human body (may not be very accurate)
@@ -7040,6 +7046,20 @@ acetyl {
 phenyl {
     molar_mass      mass 77.1057 g / amount mol
 }
+
+# Steroid hormones.
+
+progesterone            C21H30O2
+dehydroepiandrosterone  C19H28O2
+androstenediol          C19H30O2
+androstenedione         C19H26O2
+testosterone            C19H28O2
+dihydrotestosterone     C19H30O2
+estrone                 C18H22O2
+estradiol               C18H24O2
+estriol                 C18H24O3
+estetrol                C18H24O4
+
 
 !endcategory
 


### PR DESCRIPTION
This commit defines some of the more important sex hormones and their precursors, to make it easier to convert their levels between density (as preferred in the US) and molar_concentration (as preferred in Australia) without remembering any formulas.

![screenshot](https://user-images.githubusercontent.com/465303/69792152-2a848900-121a-11ea-943c-8b0dd0df002e.png)