### PR TITLE
add prolactin’s biological activity “density” (µg/mIU)

### DIFF
--- a/definitions.units
+++ b/definitions.units
@@ -207,6 +207,23 @@ sr        !steradian
 ?? that the random variable takes on the value i.
 bit       !
 
+?? One international unit of a biological agent is the biological
+?? activity equivalent to a standard amount of a substance that
+?? represents the agent (its “reference preparation”). Agents that
+?? can be measured in international units are generally found in
+?? multiple forms (such as Vitamin A) and/or not meaningfully
+?? comparable in SI units like moles (such as prolactin).
+?? WHO TRS 932, Annex 2.
+IU                              !
+
+# XXX: conflates “biological activity” and “immunological activity” to
+# avoid a conflicting quantities warning; some biological agents have
+# more than one reference preparation and/or more than one type of
+# biological activity [WHO TRS 932 pp. 80–81], but it’s unclear how
+# we would map such agents to Rink’s substance/property model
+biological_activity             ? IU
+biological_activity_density     ? mass / biological_activity
+
 ###########################################################################
 #                                                                         #
 # Prefixes (longer names must come first)                                 #
@@ -7039,6 +7056,14 @@ acetyl {
 !symbol phenyl Ph
 phenyl {
     molar_mass      mass 77.1057 g / amount mol
+}
+
+# Biological or immunological activity of reference preparations.
+
+prolactin {
+    # 4th International Standard for Prolactin, human, pituitary [WHO/BS/2016.2292]
+    # <https://apps.who.int/iris/handle/10665/253053>
+    biological_activity_density     mass 3.2 µg / biological_activity 67 mIU
 }
 
 !endcategory


### PR DESCRIPTION
This commit defines international units (IU) of biological activity, as well as the biological activity “density” of the current reference preparation of prolactin, to make it easier to convert prolactin levels between ng/mL (as preferred in the US) and mIU/L (as preferred in Australia).

I can’t find a formal term for the relationship between biological activity and mass in reference preparations, so I’ve chosen “density” by analogy with linear_density, area_density, etc.

![screenshot](https://user-images.githubusercontent.com/465303/69810758-b6a9a700-1240-11ea-9e1e-c6407b96a872.png)

[Rink-Manual.md](https://github.com/tiffany352/rink-rs/wiki/Rink-Manual) patch: <https://bucket.daz.cat/f21e684bdbc40acd.patch>