### PR TITLE
Make dates with numerical offsets get parsed correctly

### DIFF
--- a/tests/query.rs
+++ b/tests/query.rs
@@ -433,7 +433,7 @@ fn test_underscores_in_number() {
 fn test_date_input() {
     test_starts_with(
         "#2018-10-04T09:13:25.123   +2:00#",
-        "2018-10-04 11:13:25.123 +02:00",
+        "2018-10-04 09:13:25.123 +02:00",
     );
 }
 
@@ -573,4 +573,12 @@ fn test_formula() {
 #[test]
 fn test_unicode_minus() {
     test("\u{2212}10", "-10 (dimensionless)");
+}
+
+#[test]
+fn test_offset_date_math() {
+    test(
+        "#2020-01-01 05:00:00 +05:00# - #2020-01-01 00:00:00 +00:00#",
+        "0 second (time)"
+    )
 }


### PR DESCRIPTION
Currently, if you specify a date like `#2020-01-01 05:00:00 +05:00#`, instead of getting 5am in the UTC+5 timezone, you will get UTC 5am converted to the UTC+5 timezone (ie, 10am). You can test this by comparing dates that are the same and should return a time difference of 0:

```
> #2020-01-01 05:00:00 +05:00# - #2020-01-01 00:00:00 +00:00#
5 hour, 0 second (time)
```

This PR makes dates specified with offsets get parsed as local time at that offset, which is the probably what's expected. There is some code duplication here that could perhaps be avoided with wider refactoring, but it achieves the correct behavior. 