### PR TITLE
Fix crash caused by NaN

### DIFF
--- a/core/tests/query.rs
+++ b/core/tests/query.rs
@@ -610,5 +610,24 @@ fn test_offset_date_math() {
     test(
         "#2020-01-01 05:00:00 +05:00# - #2020-01-01 00:00:00 +00:00#",
         "0 second (time)",
-    )
+    );
+}
+
+#[test]
+fn test_bad_floats() {
+    // Log10
+    test("log10(-1)", "approx. NaN (dimensionless)");
+    test("log10(0)", "approx. -Inf (dimensionless)");
+    test("-log10(0)", "approx. Inf (dimensionless)");
+    test("(log10(-1) * 12 + 2) meters", "approx. NaN meter (length)");
+
+    // Log2
+    test("log2(-1)", "approx. NaN (dimensionless)");
+    test("log2(0)", "approx. -Inf (dimensionless)");
+
+    // Sqrt
+    test(
+        "sqrt(-1)",
+        "Complex numbers are not implemented: sqrt(-1 (dimensionless))",
+    );
 }

--- a/web/static/manifest.json
+++ b/web/static/manifest.json
@@ -3,7 +3,7 @@
   "short_name": "Rink",
   "theme_color": "#2196f3",
   "background_color": "#2196f3",
-  "display": "minimal-ui",
+  "display": "standalone",
   "scope": "/",
   "start_url": "/",
   "description": "A unit calculator and dimensional analysis tool.",


### PR DESCRIPTION
At least until Rink supports complex numbers, this should at least present a value instead of hanging. Fixes #68.

```
> log10(-1)
approx. NaN (dimensionless)
```