### PR TITLE
Fix month in JavaScript binding

### DIFF
--- a/rink-js/src/lib.rs
+++ b/rink-js/src/lib.rs
@@ -80,7 +80,7 @@ impl Context {
     #[wasm_bindgen(js_name = setTime)]
     pub fn set_time(&mut self, date: Date) {
         let year = date.get_utc_full_year();
-        let month = date.get_utc_month();
+        let month = date.get_utc_month() + 1;
         let day = date.get_utc_date();
         let hour = date.get_utc_hours();
         let min = date.get_utc_minutes();


### PR DESCRIPTION
In JavaScript, Date.getMonth returns a zero-based value (where zero indicates the first month of the year).

https://rustwasm.github.io/wasm-bindgen/api/js_sys/struct.Date.html#method.get_utc_month
