### PR TITLE
Update to most recent GNU units database

### DIFF
--- a/core/currency.units
+++ b/core/currency.units
@@ -1,287 +1,356 @@
-!category currencies "Currencies"
+# ISO Currency Codes
 
-EUR                     !euro
-money                 ? EUR
+ATS                    austriaschilling
+BEF                    belgiumfranc
+CYP                    cypruspound
+EEK                    estoniakroon
+FIM                    finlandmarkka
+FRF                    francefranc
+DEM                    germanymark
+GRD                    greecedrachma
+IEP                    irelandpunt
+ITL                    italylira
+LVL                    latvialats
+LTL                    lithuanialitas
+LUF                    luxembourgfranc
+MTL                    maltalira
+SKK                    slovakiakornua
+SIT                    sloveniatolar
+ESP                    spainpeseta
+NLG                    netherlandsguilder
+PTE                    portugalescudo
+CVE                    capeverdeescudo
+BGN                    bulgarialev
+BAM                    bosniaconvertiblemark
+KMF                    comorosfranc
+XOF                    westafricafranc
+XPF                    cfpfranc
+XAF                    centralafricacfafranc
+AED                    uaedirham
+AFN                    afghanafghani
+ALL                    albanialek
+AMD                    armeniadram
+ANG                    antillesguilder
+AOA                    angolakwanza
+ARS                    argentinapeso
+AUD                    australiadollar
+AWG                    arubaflorin
+AZN                    azerbaijanmanat
+BBD                    barbadosdollar
+BDT                    bangladeshtaka
+BHD                    bahraindinar
+BIF                    burundifranc
+BND                    bruneidollar
+BOB                    boliviaboliviano
+BRL                    brazilreal
+BSD                    bahamasdollar
+BWP                    botswanapula
+BYN                    belarusruble
+BYR                    oldbelarusruble
+BZD                    belizedollar
+CAD                    canadadollar
+CDF                    drcfranccongolais
+CHF                    swissfranc
+CLP                    chilepeso
+CNY                    chinayuan
+COP                    colombiapeso
+CRC                    costaricacolon
+CUP                    cubapeso
+CZK                    czechkoruna
+DJF                    djiboutifranc
+DKK                    denmarkkrona
+DOP                    dominicanrepublicpeso
+DZD                    algeriadinar
+EGP                    egyptpound
+ERN                    eritreanakfa
+ETB                    ethiopiabirr
+EUR                    euro
+FJD                    fijidollar
+GBP                    ukpound
+GEL                    georgialari
+GHS                    ghanacedi
+GIP                    gibraltarpound
+GMD                    gambiadalasi
+GNF                    guineafranc
+GTQ                    guatemalaquetzal
+GYD                    guyanadollar
+HKD                    hongkongdollar
+HNL                    honduraslempira
+HRK                    croatiakuna
+HTG                    haitigourde
+HUF                    hungariaforint
+IDR                    indonesiarupiah
+ILS                    israelnewshekel
+INR                    indiarupee
+IQD                    iraqdinar
+IRR                    iranrial
+ISK                    icelandkrona
+JMD                    jamaicadollar
+JOD                    jordandinar
+JPY                    japanyen
+KES                    kenyaschilling
+KGS                    kyrgyzstansom
+KHR                    cambodiariel
+KRW                    southkoreawon
+KWD                    kuwaitdinar
+KZT                    kazakhstantenge
+LAK                    laokip
+LBP                    lebanonpound
+LKR                    srilankarupee
+LRD                    liberiadollar
+LSL                    lesotholoti
+LYD                    libyadinar
+MAD                    moroccodirham
+MDL                    moldovaleu
+MGA                    madagascarariary
+MKD                    macedoniadenar
+MMK                    myanmarkyat
+MNT                    mongoliatugrik
+MOP                    macaupataca
+MRO                    mauritaniaoldouguiya
+MRU                    mauritaniaouguiya
+MUR                    mauritiusrupee
+MVR                    maldiverufiyaa
+MWK                    malawikwacha
+MXN                    mexicopeso
+MYR                    malaysiaringgit
+MZN                    mozambiquemetical
+NAD                    namibiadollar
+NGN                    nigerianaira
+NIO                    nicaraguacordobaoro
+NOK                    norwaykrone
+NPR                    nepalrupee
+NZD                    newzealanddollar
+OMR                    omanrial
+PAB                    panamabalboa
+PEN                    perunuevosol
+PGK                    papuanewguineakina
+PHP                    philippinepeso
+PKR                    pakistanrupee
+PLN                    polandzloty
+PYG                    paraguayguarani
+QAR                    qatarrial
+RON                    romanianewlei
+RSD                    serbiadinar
+RUB                    russiaruble
+RWF                    rwandafranc
+SAR                    saudiarabiariyal
+SBD                    solomonislandsdollar
+SCR                    seychellesrupee
+SDG                    sudanpound
+SEK                    swedenkrona
+SGD                    singaporedollar
+SLL                    sierraleoneleone
+SOS                    somaliaschilling
+SRD                    surinamedollar
+SSP                    southsudanpound
+STN                    saotome&principedobra
+SVC                    elsalvadorcolon
+SYP                    syriapound
+SZL                    swazilandlilangeni
+THB                    thailandbaht
+TJS                    tajikistansomoni
+TMT                    turkmenistanmanat
+TND                    tunisiadinar
+TOP                    tongapa'anga
+TRY                    turkeylira
+TTD                    trinidadandtobagodollar
+TWD                    taiwandollar
+TZS                    tanzaniashilling
+UAH                    ukrainehryvnia
+UGX                    ugandaschilling
+USD                    US$
+UYU                    uruguaypeso
+UZS                    uzbekistansum
+VES                    venezuelabolivarsoberano
+VND                    vietnamdong
+VUV                    vanuatuvatu
+WST                    samoatala
+XCD                    eastcaribbeandollar
+YER                    yemenrial
+ZAR                    southafricarand
+ZMW                    zambiakwacha
 
-# Symbols + names
-# EU
-€                       EUR
+# Currency exchange rates source 
 
-# US
-$                       USD
-dollar                  USD
-usdollar                USD
-cent                    $ 0.01
-penny                   cent
-¢                       cent
-buck                    USD
-fin                     5 USD
-sawbuck                 10 USD
-usgrand                 1000 USD
-greenback               USD
+!message Currency exchange rates from FloatRates (USD base) on 2020-11-15
 
-# Japan
-¥                       JPY
-yen                     JPY
+austriaschilling          1|13.7603 euro
+belgiumfranc              1|40.3399 euro
+cypruspound               1|0.585274 euro
+estoniakroon              1|15.6466 euro # Equal to 1|8 germanymark
+finlandmarkka             1|5.94573 euro
+francefranc               1|6.55957 euro
+germanymark               1|1.95583 euro
+greecedrachma             1|340.75 euro
+irelandpunt               1|0.787564 euro
+italylira                 1|1936.27 euro
+latvialats                1|0.702804 euro
+lithuanialitas            1|3.4528 euro
+luxembourgfranc           1|40.3399 euro
+maltalira                 1|0.4293 euro
+slovakiakornua            1|30.1260 euro
+sloveniatolar             1|239.640 euro
+spainpeseta               1|166.386 euro
+netherlandsguilder        1|2.20371 euro
+portugalescudo            1|200.482 euro
+capeverdeescudo           0.010574773115875 USD
+bulgarialev               0.60411147096881 USD
+bosniaconvertiblemark     0.60281467841641 USD
+comorosfranc              0.0024187820597133 USD
+westafricafranc           1|655.957 euro
+cfpfranc                  1|119.33 euro
+centralafricacfafranc     0.0017975937625008 USD
+uaedirham                 0.27323770604958 USD
+afghanafghani             0.01301433644614 USD
+albanialek                0.0095651716427731 USD
+armeniadram               0.0020457859256011 USD
+antillesguilder           0.55804287781138 USD
+angolakwanza              0.0015257135341313 USD
+argentinapeso             0.012582091516257 USD
+australiadollar           0.72437150231423 USD
+arubaflorin               0.55341312639747 USD
+azerbaijanmanat           0.5884620681835 USD
+barbadosdollar            0.49964233673334 USD
+bangladeshtaka            0.01191071593574 USD
+bahraindinar              2.6541134081646 USD
+burundifranc              0.00051742733131658 USD
+bruneidollar              0.74098555911885 USD
+boliviaboliviano          0.14552826655361 USD
+brazilreal                0.1806578917623 USD
+bahamasdollar             1.0040247270814 USD
+botswanapula              0.089367074554766 USD
+belarusruble              0.38986335160716 USD
+oldbelarusruble           1|10000 BYN
+belizedollar              0.49693542022886 USD
+canadadollar              0.76064243291944 USD
+drcfranccongolais         0.00050979876364594 USD
+swissfranc                1.0935879369562 USD
+chilepeso                 0.0013182903414838 USD
+chinayuan                 0.15123061116205 USD
+colombiapeso              0.0002742486618271 USD
+costaricacolon            0.0016357110546689 USD
+cubapeso                  1.0040247270814 USD
+czechkoruna               0.04463481699542 USD
+djiboutifranc             0.0056267262922532 USD
+denmarkkrona              0.1586648171402 USD
+dominicanrepublicpeso     0.017124819150335 USD
+algeriadinar              0.0077957189022544 USD
+egyptpound                0.063948783176438 USD
+eritreanakfa              0.066447454951991 USD
+ethiopiabirr              0.026305405760884 USD
+euro                      1.18169056858 USD
+fijidollar                0.47554912534526 USD
+ukpound                   1.3163679306895 USD
+georgialari               0.31202099082079 USD
+ghanacedi                 0.17363317418476 USD
+gibraltarpound            1.3225728675592 USD
+gambiadalasi              0.019124029988163 USD
+guineafranc               0.00010232802840984 USD
+guatemalaquetzal          0.12865973957648 USD
+guyanadollar              0.0047938971458635 USD
+hongkongdollar            0.1289782530199 USD
+honduraslempira           0.04079968433513 USD
+croatiakuna               0.15603545681162 USD
+haitigourde               0.015493883993161 USD
+hungariaforint            0.0033218714631897 USD
+indonesiarupiah           7.0567517536618e-05 USD
+israelnewshekel           0.29698083444814 USD
+indiarupee                0.013398220300786 USD
+iraqdinar                 0.00084931004929697 USD
+iranrial                  2.407901352909e-05 USD
+icelandkrona              0.0072984618253828 USD
+jamaicadollar             0.0068394054978297 USD
+jordandinar               1.4112723074021 USD
+japanyen                  0.0095338769466235 USD
+kenyaschilling            0.0091942654215438 USD
+kyrgyzstansom             0.012291616976317 USD
+cambodiariel              0.00024595554386428 USD
+southkoreawon             0.00089874904551453 USD
+kuwaitdinar               3.2703360607932 USD
+kazakhstantenge           0.0023276947101462 USD
+laokip                    0.00010811521767723 USD
+lebanonpound              0.00066958639938142 USD
+srilankarupee             0.0054307510193344 USD
+liberiadollar             0.0057608838616337 USD
+lesotholoti               0.064842825200579 USD
+libyadinar                0.74557194892141 USD
+moroccodirham             0.10990270310713 USD
+moldovaleu                0.058379120923552 USD
+madagascarariary          0.00025463632776535 USD
+macedoniadenar            0.019235827962646 USD
+myanmarkyat               0.00077258976719719 USD
+mongoliatugrik            0.00035354465342628 USD
+macaupataca               0.12534525845061 USD
+mauritaniaoldouguiya      1|10 MRU
+mauritaniaouguiya         0.026121267920559 USD
+mauritiusrupee            0.024937892088168 USD
+maldiverufiyaa            0.064790214389058 USD
+malawikwacha              0.0013210574773116 USD
+mexicopeso                0.048792655886347 USD
+malaysiaringgit           0.2425589198853 USD
+mozambiquemetical         0.013757727212943 USD
+namibiadollar             0.064842825200579 USD
+nigerianaira              0.0026329231627275 USD
+nicaraguacordobaoro       0.028775148044583 USD
+norwaykrone               0.109212642295 USD
+nepalrupee                0.008437458897804 USD
+newzealanddollar          0.68289556014338 USD
+omanrial                  2.5995888526581 USD
+panamabalboa              1.0040247270814 USD
+perunuevosol              0.27486151570868 USD
+papuanewguineakina        0.28569189609443 USD
+philippinepeso            0.020746180723217 USD
+pakistanrupee             0.0063212164558259 USD
+polandzloty               0.26309560319497 USD
+paraguayguarani           0.00014271608189059 USD
+qatarrial                 0.27483665660371 USD
+romanianewlei             0.24261629103244 USD
+serbiadinar               0.010058987000612 USD
+russiaruble               0.012905960169361 USD
+rwandafranc               0.0010224911219256 USD
+saudiarabiariyal          0.26664545319217 USD
+solomonislandsdollar      0.12355649085888 USD
+seychellesrupee           0.048875443903723 USD
+sudanpound                0.01817703538077 USD
+swedenkrona               0.11529218746416 USD
+singaporedollar           0.74129934539381 USD
+sierraleoneleone          0.00010048665000658 USD
+somaliaschilling          0.0017314218071814 USD
+surinamedollar            0.070761541496778 USD
+southsudanpound           0.0057448375641194 USD
+saotome&principedobra     0.045850322241221 USD
+elsalvadorcolon           0.11442851505985 USD
+syriapound                0.00078916217282656 USD
+swazilandlilangeni        0.064842825200579 USD
+thailandbaht              0.032959744095361 USD
+tajikistansomoni          0.096142609332913 USD
+turkmenistanmanat         0.28866179160445 USD
+tunisiadinar              0.36532111878084 USD
+tongapa'anga              0.43661712481916 USD
+turkeylira                0.13000050457823 USD
+trinidadandtobagodollar   0.14762593713008 USD
+taiwandollar              0.035187899173014 USD
+tanzaniashilling          0.00043193476259372 USD
+ukrainehryvnia            0.035569247149676 USD
+ugandaschilling           0.00027041957122188 USD
+US$                       !           # Base unit, the primitive unit of currency
+uruguaypeso               0.023369824569124 USD
+uzbekistansum             9.7503975175856e-05 USD
+venezuelabolivarsoberano  1.6394537303329e-06 USD
+vietnamdong               4.3393629626082e-05 USD
+vanuatuvatu               0.0088980665526765 USD
+samoatala                 0.38487439168749 USD
+eastcaribbeandollar       0.36985400499803 USD
+yemenrial                 0.0040128896488229 USD
+southafricarand           0.064138629851988 USD
+zambiakwacha              0.048138892542417 USD
+bitcoin                   15306.69 US$ # From services.packetizer.com/btc
 
-# Bulgaria
-лв                      BGN
-lev                     BGN
 
-# Czech Republic
-Kč                      CZK
-koruna                  CZK
+# Precious metals prices from Packetizer (services.packetizer.com/spotprices)
 
-# Denmark
-denmarkkr               DKK
-denmarkkroner           DKK
+silverprice        24.67 US$/troyounce
+goldprice          1889.49 US$/troyounce
+platinumprice      893.67 US$/troyounce
 
-# UK
-£                       GBP
-britainpound            GBP
-pence                   1|100 GBP
-
-quid                    britainpound        # Slang names
-fiver                   5 quid
-tenner                  10 quid
-monkey                  500 quid
-brgrand                 1000 quid
-bob                     shilling
-
-shilling                1|20 britainpound   # Before decimalisation, there
-oldpence                1|12 shilling       # were 20 shillings to a pound,
-farthing                1|4 oldpence        # each of twelve old pence
-guinea                  21 shilling         # Still used in horse racing
-crown                   5 shilling
-florin                  2 shilling
-groat                   4 oldpence
-tanner                  6 oldpence
-brpenny                 0.01 britainpound
-tuppence                2 pence
-tuppenny                tuppence
-#ha'penny                halfbrpenny
-#hapenny                 ha'penny
-oldpenny                oldpence
-oldtuppence             2 oldpence
-oldtuppenny             oldtuppence
-threepence              3 oldpence    # threepence never refers to new money
-threepenny              threepence
-oldthreepence           threepence
-oldthreepenny           threepence
-#oldhalfpenny            halfoldpenny
-#oldha'penny             oldhalfpenny
-#oldhapenny              oldha'penny
-brpony                  25 britainpound
-
-# Hungary
-Ft                      HUF
-forint                  HUF
-
-# Poland
-zł                      PLN
-złoty                   PLN
-
-# Romania
-leu                     RON
-lei                     RON
-
-# Sweden
-krona                   SEK
-swedishkroner           SEK
-swedishkr               SEK
-
-# Switzerland
-franc                   CHF
-Fr                      CHF
-
-# Norway
-krone                   NOK
-øre                     1|100 NOK
-
-# Croatia
-kuna                    HRK
-lipa                    1|100 HRK
-
-# Russia
-₽                       RUB
-ruble                   RUB
-rouble                  RUB
-рубль                   RUB
-копеика                 1|100 RUB
-kopek                   копеика
-копеики                 копеика
-
-# Turkey
-₺                       TRY
-lira                    TRY
-kuruş                   1|100 TRY
-
-# Australia
-A$                      AUD
-aucent                  1|100 AUD
-audollar                AUD
-
-# Brazil
-real                    BRL
-R$                      BRL
-centavos                1|100 BRL
-brdollar                BRL
-
-# Canada
-C$                      CAD
-cacent                  1|100 CAD
-cadollar                CAD
-canadadollar            CAD
-
-loony                   1 canadadollar    # This coin depicts a loon
-toony                   2 canadadollar
-
-# PRC
-RMB                     CNY
-元                      CNY
-圆                      CNY
-yuan                    CNY
-CM¥                     CNY
-角                      1|10 yuan
-jiao                    角
-分                      1|10 角
-fen                     分
-
-# Hong Kong
-H$                      HKD
-hkdollar                HKD
-hkcent                  1|100 HKD
-
-# Indonesia
-rupiah                  IDR
-Rp                      IDR
-perak                   rupiah
-sen                     1|100 rupiah
-
-# Israel
-₪                       ILS
-shekel                  ILS
-שֶׁקֶל                     ILS
-agora                   1|100 shekel
-
-# India
-₹                       INR
-rupee                   INR
-paise                   1|100 INR
-
-# South Korea
-원                      KRW
-₩                       KRW
-won                     KRW
-jeon                    1|100 won
-
-# Mexico
-mex$                    MXN
-centavo                 1|100 MXN
-
-# Malaysia
-ringgit                 MYR
-RM                      MYR
-malaysiasen             1|100 ringgit
-
-# New Zealand
-NZ$                     NZD
-nzdollar                NZD
-kiwi                    NZD
-nzcent                  1|100 NZD
-
-# The Phillipines
-piso                    PHP
-₱                       PHP
-sentimo                 1|100 piso
-phcentavos              sentimo
-P$                      PHP
-
-# Singapore
-S$                      SGD
-sgcent                  1|100 SGD
-
-# Thailand
-บาท                     THB
-baht                    THB
-฿                       baht
-สตางค์                   1|100 บาท
-satang                  สตางค์
-
-# South Africa
-rand                    ZAR
-zacent                  1|100 ZAR
-
-# Aliases
-# mark                    germanymark
-# bolivar                 venezuelabolivar
-# VEF                     bolivar
-# venezuelanbolivarfuerte venezuelabolivar
-# bolivarfuerte           bolivar        # The currency was revalued by
-# oldbolivar              1|1000 bolivar # a factor of 1000.
-# VEB                     oldbolivar
-# peseta                  spainpeseta
-# rand                    southafricarand
-# escudo                  portugalescudo
-# guilder                 netherlandsguilder
-# hollandguilder          netherlandsguilder
-# peso                    mexicopeso
-# yen                     japanyen
-# lira                    italylira
-# rupee                   indiarupee
-# drachma                 greecedrachma
-# franc                   francefranc
-# markka                  finlandmarkka
-# britainpound            unitedkingdompound
-# greatbritainpound       unitedkingdompound
-# unitedkingdompound      ukpound
-# poundsterling           britainpound
-# yuan                    chinayuan
-
-# Some European currencies have permanent fixed exchange rates with
-# the Euro.  These rates were taken from the EC's web site:
-# http://ec.europa.eu/economy_finance/euro/adoption/conversion/index_en.htm
-
-austriaschilling        1|13.7603 euro
-belgiumfranc            1|40.3399 euro
-estoniakroon            1|15.6466 euro # Equal to 1|8 germanymark
-finlandmarkka           1|5.94573 euro
-francefranc             1|6.55957 euro
-germanymark             1|1.95583 euro
-greecedrachma           1|340.75 euro
-irelandpunt             1|0.787564 euro
-italylira               1|1936.27 euro
-luxembourgfranc         1|40.3399 euro
-netherlandsguilder      1|2.20371 euro
-portugalescudo          1|200.482 euro
-spainpeseta             1|166.386 euro
-cypruspound             1|0.585274 euro
-maltalira               1|0.429300 euro
-sloveniatolar           1|239.640 euro
-slovakiakoruna          1|30.1260 euro
-
-# Money on the gold standard, used in the late 19th century and early
-# 20th century.
-
-# olddollargold           23.22 grains goldprice  # Used until 1934
-# newdollargold           96|7 grains goldprice   # After Jan 31, 1934
-# dollargold              newdollargold
-# poundgold               113 grains goldprice
-# goldounce               goldprice troyounce
-# silverounce             silverprice troyounce
-# platinumounce		platinumprice troyounce
-# XAU                     goldounce
-# XPT                     platinumounce
-# XAG                     silverounce
-
-# Nominal masses of US coins.  Note that dimes, quarters and half dollars
-# have weight proportional to value.  Before 1965 it was $40 / kg.
-
-#USpennyweight           2.5 grams         # Since 1982, 48 grains before
-#USnickelweight          5 grams
-#USdimeweight            USD 0.10 / (20 USD / lb)   # Since 1965
-#USquarterweight         USD 0.25 / (20 USD / lb)   # Since 1965
-#UShalfdollarweight      USD 0.50 / (20 USD / lb)   # Since 1971
-#USdollarmass            8.1 grams
-
-!endcategory

--- a/core/definitions.units
+++ b/core/definitions.units
@@ -2,10 +2,9 @@
 # This file is the units database for use with GNU units, a units conversion
 # program by Adrian Mariano adrianm@gnu.org
 #
-# August 2015 Version 2.13
+# September 2020 Version 3.09
 #
-# Copyright (C) 1996, 1997, 1998, 1999, 2000, 2001, 2002, 2004, 2005, 2006
-#               2007, 2008, 2009, 2010, 2011, 2012, 2013, 2014, 2015
+# Copyright (C) 1996-2002, 2004-2020
 # Free Software Foundation, Inc
 #
 # This program is free software; you can redistribute it and/or modify
@@ -27,15 +26,16 @@
 #
 # Improvements and corrections are welcome.
 #
-# Fundamental constants in this file are the 2014 CODATA recommended values.
+# Fundamental constants in this file are the 2018 CODATA recommended values.
 #
 # Most units data was drawn from
 #            1. NIST Special Publication 811, Guide for the
 #                 Use of the International System of Units (SI).
-#                 Barry N. Taylor. 1995
+#                 Barry N. Taylor. 2008
+#                 https://www.nist.gov/pml/special-publication-811
 #            2. CRC Handbook of Chemistry and Physics 70th edition
 #            3. Oxford English Dictionary
-#            4. Websters New Universal Unabridged Dictionary
+#            4. Webster's New Universal Unabridged Dictionary
 #            5. Units of Measure by Stephen Dresner
 #            6. A Dictionary of English Weights and Measures by Ronald Zupko
 #            7. British Weights and Measures by Ronald Zupko
@@ -55,7 +55,7 @@
 #           17. CODATA Recommended Values of Physical Constants available at
 #                   http://physics.nist.gov/cuu/Constants/index.html
 #           18. How Many?  A Dictionary of Units of Measurement.  Available at
-#                   http://www.unc.edu/~rowlett/units/index.html
+#                   http://www.ibiblio.org/units/
 #           19. Numericana.  http://www.numericana.com
 #           20. UK history of measurement
 #                   http://www.ukmetrication.com/history.htm
@@ -65,17 +65,21 @@
 #           22. NIST Special Publication 447, Weights and Measures Standards
 #                 of the the United States: a brief history. Lewis V. Judson.
 #                 1963; rev. 1976
-#
-# Thanks to Jeff Conrad for assistance in ferreting out unit definitions.
+#           23. CRC Handbook of Chemistry and Physics, 96th edition
+#           24. Dictionary of Scientific Units, 6th ed.  H.G.  Jerrard and D.B.
+#                 McNeill. 1992
+#           25. NIST Special Publication 330, The International System of
+#                 Units (SI). ed. Barry N. Taylor and Ambler Thompson. 2008
+#                 https://www.nist.gov/pml/special-publication-330
+#           26. BIPM Brochure, The International System of Units (SI).
+#                 9th ed., 2019
+#                 https://www.bipm.org/en/publications/si-brochure/
 #
 ###########################################################################
 #
 # If units you use are missing or defined incorrectly, please contact me.
 # If your country's local units are missing and you are willing to supply
 # them, please send me a list.
-#
-# I added shoe size information but I'm not convinced that it's correct.
-# If you know anything about shoe sizes please contact me.
 #
 ###########################################################################
 
@@ -123,6 +127,21 @@
 
 !set UNITS_ENGLISH US   # Default setting for English units
 
+!set UNITS_SYSTEM default   # Set a default value
+
+!varnot UNITS_SYSTEM si emu esu gaussian gauss hlu natural natural-gauss hartree planck planck-red default 
+!message Unknown unit system given with -u or UNITS_SYSTEM environment variable
+!message Valid systems: si, emu, esu, gauss[ian], hlu, natural, natural-gauss
+!message                planck, planck-red, hartree
+!message Using SI
+!prompt (SI)
+!endvar
+
+!var UNITS_SYSTEM si
+!message SI units selected
+!prompt (SI)
+!endvar
+
 ###########################################################################
 #                                                                         #
 # Primitive units.  Any unit defined to contain a '!' character is a      #
@@ -134,51 +153,254 @@
 #
 # SI units
 #
+# On 20 May 2019, the SI was revised to define the units by fixing the
+# values of physical constants that depend on those units.
+#
+# https://www.nist.gov/si-redefinition/
+#
+# The BIPM--the International Bureau of Weights and Measures--provides a
+# succinct description of the new SI in its Concise Summary:
+#
+# https://www.bipm.org/utils/common/pdf/si-brochure/SI-Brochure-9-concise-EN.pdf
+#
+#     The SI is the system of units in which:
+#
+#       *  the unperturbed ground state hyperfine transition frequency of the
+#          caesium 133 atom is delta nu_Cs = 9 192 631 770 Hz,
+#       *  the speed of light in vacuum, c, is 299 792 458 m/s,
+#       *  the Planck constant, h, is 6.626 070 15 * 10^-34 J s,
+#       *  the elementary charge, e, is 1.602 176 634 * 10^-19 C,
+#       *  the Boltzmann constant, k, is 1.380 649 * 10^-23 J/K,
+#       *  the Avogadro constant, N_A, is 6.022 140 76 * 10^23 mol^-1,
+#       *  the luminous efficacy of monochromatic radiation of frequency
+#          540 * 10^12 Hz, K_cd, is 683 lm/W,
+#
+#     where the hertz, joule, coulomb, lumen, and watt, with unit symbols Hz,
+#     J, C, lm, and W, respectively, are related to the units second, metre,
+#     kilogram, ampere, kelvin, mole, and candela, with unit symbols s, m, kg,
+#     A, K, mol, and cd, respectively, according to Hz = s^–1, J = kg m^2 s^–2,
+#     C = A s, lm = cd m^2 m^–2 = cd sr, and W = kg m^2 s^–3.
+# 
+#     These definitions specify the exact numerical value of each constant when
+#     its value is expressed in the corresponding SI unit.  By fixing the exact
+#     numerical value the unit becomes defined, since the product of the
+#     numerical value and the unit has to equal the value of the constant,
+#     which is invariant.
+# 
+#     The defining constants have been chosen such that, when taken together,
+#     their units cover all of the units of the SI.  In general, there is no
+#     one-to-one correspondence between the defining constants and the SI base
+#     units.  Any SI unit is a product of powers of these seven constants and a
+#     dimensionless factor.
+# 
+# Until 2018, the SI was defined in terms of base units and derived units.
+# These categories are no longer essential in the SI, but they are maintained
+# in view of their convenience and widespread use.  They are arguably more
+# intuitive than the new definitions.  (They are also essential to the
+# operation of GNU units.)  The definitions of the base units, which follow
+# from the definition of the SI in terms of the seven defining constants, are
+# given below.
+#
 
-!category base_units "SI Base Units"
+s         !      # The second, symbol s, is the SI unit of time.  It is defined
+second    s      # by taking the fixed numerical value of the unperturbed
+                 # ground-state hyperfine transition frequency of the
+                 # cesium-133 atom to be 9 192 1631 770 when expressed in the
+                 # unit Hz, which is equal to 1/s.  
+                 #
+                 # This definition is a restatement of the previous one, the
+                 # duration of 9192631770 periods of the radiation corresponding
+                 # to the cesium-133 transition. 
 
-?? Equal to the mass of the international prototype of the
-?? kilogram. 3rd CGPM (1901, CR, 70).
-kg        !kilogram
+c_SI      299792458
+c         299792458 m/s   # speed of light in vacuum (exact)
 
-?? Duration of 9192631770 periods of the radiation corresponding to
-?? the transition between the two hyperfine levels of the ground state
-?? of the cesium-133 atom at rest at a temperature of 0 K. 13th CGPM
-?? (1968/68, Resolution 1; CR; 103).
-s         !second
+m         !      # The metre, symbol m, is the SI unit of length.  It is
+meter     m      # defined by taking the fixed numerical value of the speed
+metre     m      # of light in vacuum, c, to be 299 792 458 when expressed in
+                 # units of m/s.
+                 #
+                 # This definition is a rewording of the previous one and is
+                 # equivalent to defining the meter as the distance light
+                 # travels in 1|299792458 seconds.  The meter was originally
+                 # intended to be 1e-7 of the length along a meridian from the
+                 # equator to a pole.
 
-?? Length of the path travelled by light in vacuum during a time
-?? interval of 1 / 299 792 458 of a second. 17th CGPM (1983, CR, 70).
-m         !meter
+h_SI      6.62607015e-34
+h         6.62607015e-34 J s # Planck constant (exact)
 
-?? The constant current which, if maintained in two straight parallel
-?? conductors of infinite length, of negligible circular
-?? cross-section, and placed 1 meter apart in vacuum, would produce
-?? between those conductors a force equal to 2e-7 newton per meter of
-?? length. 9th CGPM (1948).
-A         !ampere
-amp       A
+kg        !      # The kilogram, symbol kg, is the SI unit of mass.  It is
+kilogram  kg     # defined by taking the fixed numerical value of the Planck
+                 # constant, h, to be 6.626 070 15 * 10^-34 when expressed in
+                 # the unit J s which is equal to kg m^2 / s.
+                 # 
+                 # One advantage of fixing h to define the kilogram is that this
+                 # affects constants used to define the ampere.  If the kg were
+                 # defined by directly fixing the mass of something, then h
+                 # would be subject to error.
+                 #
+                 # The previous definition of the kilogram was the mass of the
+                 # international prototype kilogram.  The kilogram was the last
+                 # unit whose definition relied on reference to an artifact.
+                 #
+                 # It is not obvious what this new definition means, or
+                 # intuitively how fixing Planck's constant defines the
+                 # kilogram.  To define the kilogram we need to give the mass
+                 # of some reference in kilograms.  Previously the prototype in
+                 # France served as this reference, and it weighed exactly 1
+                 # kg.  But the reference can have any weight as long as you
+                 # know the weight of the reference.  The new definition uses
+                 # the "mass" of a photon, or more accurately, the mass
+                 # equivalent of the energy of a photon.  The energy of a
+                 # photon depends on its frequency.  If you pick a frequency,
+                 # f, then the energy of the photon is hf, and hence the mass
+                 # equivalent is hf/c^2.  If we reduce this expression using
+                 # the constant defined values for h and c the result is a
+                 # value in kilograms for the mass-equivalent of a photon of
+                 # frequency f, which can therefore define the size of the
+                 # kilogram.
+                 #
+                 # For more on the relationship between mass an Planck's
+                 # constant:
+                 #
+                 # https://www.nist.gov/si-redefinition/kilogram-mass-and-plancks-constant
+                 # This definition may still seem rather abstract: you can't
+                 # place a "kilogram of radiation" on one side of a balance.
+                 # Metrologists realize the kilogram using a Kibble Balance, a
+                 # device which relates mechanical energy to electrical energy
+                 # and can measure mass with extreme accuracy if h is known.
+                 #
+                 # For more on the Kibble Balance see
+                 #
+                 # https://www.nist.gov/si-redefinition/kilogram-kibble-balance
+                 # https://en.wikipedia.org/wiki/Kibble_balance
 
-?? The luminous intensity, in a given direction, of a source that
-?? emits monochromatic radiation of frequency 540e12 hertz and that
-?? has a radiant intensity in that direction of 1/683 watt per
-?? steradian. 16th CGPM (1979, Resolution 3; CR, 100).
-cd        !candela
+k_SI      1.380649e-23
+boltzmann 1.380649e-23 J/K   # Boltzmann constant (exact)
+k         boltzmann
 
-?? The amount of substance a system which contains as many elementary
-?? entities as there are atoms in 0.012 kilogram of carbon 12 at rest
-?? and in their ground state. When the mole is used, the elementary
-?? entities must be specified and may be atoms, molecules, ions,
-?? electrons, other particles, or specified groups of such
-?? particles. 14th CGPM (1971, Resolution 3; CR, 78).
-mol       !mole
+K         !      # The kelvin, symbol K, is the SI unit of thermodynamic
+kelvin    K      # temperature.  It is defined by taking the fixed numerical
+                 # value of the Boltzmann constant, k, to be 1.380 649 * 10^-23
+                 # when expressed in the unit J/K, which is equal to 
+                 # kg m^2/s^2 K.
+                 #
+                 # The boltzmann constant establishes the relationship between
+                 # energy and temperature.  The average thermal energy carried
+                 # by each degree of freedom is kT/2.  A monatomic ideal gas
+                 # has three degrees of freedom corresponding to the three
+                 # spatial directions, which means its thermal energy is
+                 # (3/2) k T.
+                 #
+                 # The previous definition of the kelvin was based on the
+                 # triple point of water.  The change in the definition of the
+                 # kelvin will not have much effect on measurement practice.
+                 # Practical temperature calibration makes use of two scales,
+                 # the International Temperature Scale of 1990 (ITS-90), which
+                 # covers the range of 0.65 K to 1357.77K and the Provisional
+                 # Low Temperature Scale of 2000 (PLTS-2000), which covers the
+                 # range of 0.9 mK to 1 K.
+                 # https://www.bipm.org/en/committees/cc/cct/publications-cc.html
+                 #
+                 # The ITS-90 contains 17 reference points including things
+                 # like the triple point of hydrogen (13.8033 K) or the
+                 # freezing point of gold (1337.33 K), and of course the triple
+                 # point of water.  The PLTS-2000 specifies four reference
+                 # points, all based on properties of helium-3.
+                 #
+                 # The redefinition of the kelvin will not affect the values of
+                 # these reference points, which have been determined by
+                 # primary thermometry, using thermometers that rely only on
+                 # relationships that allow temperature to be calculated
+                 # directly without using any unknown quantities. Examples
+                 # include acoustic thermometers, which measure the speed of
+                 # sound in a gas, or electronic thermometers, which measure
+                 # tiny voltage fluctuations in resistors. Both variables
+                 # depend directly on temperature.
 
-?? The fraction 1 / 273.16 of the thermodynamic temperature of the
-?? triple point of water. 13th CGPM (1967/68, Resolution 4; CR, 104).
-K         !kelvin
+e_SI      1.602176634e-19
+e         1.602176634e-19 C  # electron charge (exact)
 
-!endcategory
+A         !      # The ampere, symbol A, is the SI unit of electric current.
+ampere    A      # It is defined by taking the fixed numerical value of the
+amp       ampere # elementary charge, e, to be 1.602 176 634 * 10^-19 when
+                 # expressed in the unit C, which is equal to A*s.
+                 #
+                 # The previous definition was the current which produces a
+                 # force of 2e-7 N/m between two infinitely long wires a meter
+                 # apart.  This definition was difficult to realize accurately.
+                 #
+                 # The ampere is actually realized by establishing the volt and
+                 # the ohm, since A = V / ohm.  These measurements can be done
+                 # using the Josephson effect and the quantum Hall effect,
+                 # which accurately measure voltage and resistance, respectively,
+                 # with reference to two fixed constants, the Josephson
+                 # constant, K_J=2e/h and the von Klitzing constant, R_K=h/e^2.
+                 # Under the previous SI system, these constants had official
+                 # fixed values, defined in 1990.  This created a situation
+                 # where the standard values for the volt and ohm were in some
+                 # sense outside of SI because they depended primarily on
+                 # constants different from the ones used to define SI. After
+                 # the revision, since e and h have exact definitions, the
+                 # Josephson and von Klitzing constants will also have exact
+                 # definitions that derive from SI instead of the conventional
+                 # 1990 values.
+                 #
+                 # In fact we know that there is a small offset between the
+                 # conventional values of the electrical units based on the
+                 # conventional 1990 values and the SI values.  The new
+                 # definition, which brings the practical electrical units back
+                 # into SI, will lead to a one time change of +0.1ppm for
+                 # voltage values and +0.02ppm for resistance values.
+                 #
+                 # The previous definition resulted in fixed exact values for
+                 # the vacuum permeability (mu0), the impedance of free space
+                 # (Z0), the vacuum permittivity (epsilon0), and the Coulomb
+                 # constant. With the new definition, these four values are
+                 # subject to experimental error.
 
+avogadro  6.02214076e23 / mol # Size of a mole (exact)
+N_A       avogadro
+
+mol       !      # The mole, symbol mol, is the SI unit of amount of
+mole      mol    # substance.  One mole contains exactly 6.022 140 76 * 10^23
+                 # elementary entities.  This number is the fixed numerical
+                 # value of the Avogadro constant, N_A, when expressed in the
+                 # unit 1/mol and is called the Avogadro number.  The amount of
+                 # substance, symbol n, of a system is a measure of the number
+                 # of specified elementary entities.  An elementary entity may
+                 # be an atom, a molecule, an ion, an electron, any other
+                 # particle or specified group of particles.
+                 #
+                 # The atomic mass unit (u) is defined as 1/12 the mass of
+                 # carbon-12.  Previously the mole was defined so that a mole
+                 # of carbon-12 weighed exactly 12g, or N_A u = 1 g/mol
+                 # exactly. This relationship is now an experimental, 
+                 # approximate relationship.
+                 #
+                 # To determine the size of the mole, researchers used spheres
+                 # of very pure silicon-28 that weighed a kilogram.  They
+                 # measured the molar mass of Si-28 using mass spectrometry and
+                 # used X-ray diffraction interferometry to determine the
+                 # spacing of the silicon atoms in the sphere.  Using the
+                 # sphere's volume it was then possible to determine the number
+                 # of silicon atoms in the sphere, and hence determine the
+                 # Avogadro constant.  The results of this experiment were used to 
+                 # define N_A, which is henceforth a fixed, unchanging quantity.  
+                 
+cd        !      # The candela, symbol cd, is the SI unit of luminous intensity
+candela   cd     # in a given direction.  It is defined by taking the fixed
+                 # numerical value of the luminous efficacy of monochromatic
+                 # radiation of the frequency 540e12 Hz to be 683 when
+                 # expressed in the unit lumen/watt, which is equal to
+                 # cd sr/W, or cd sr s^3/kg m^2
+                 #
+                 # This definition is a rewording of the previous definition.
+                 # Luminous intensity differs from radiant intensity (W/sr) in
+                 # that it is adjusted for human perceptual dependence on
+		 # wavelength.  The frequency of 540e12 Hz (yellow;
+		 # wavelength approximately 555 nm in vacuum) is where human
+		 # perception is most efficient.
 #
 # The radian and steradian are defined as dimensionless primitive units.
 # The radian is equal to m/m and the steradian to m^2/m^2 so these units are
@@ -188,49 +410,34 @@ K         !kelvin
 # arguments to functions.
 #
 
-?? The angle subtended at the center of a circle by an arc equal in
-?? length to the radius of the circle
-radian    !
-
-?? Solid angle which cuts off an area of the surface of the sphere
-?? equal to that of a square with sides of length equal to the radius
-?? of the sphere
-sr        !steradian
+radian    !dimensionless   # The angle subtended at the center of a circle by
+                           #   an arc equal in length to the radius of the
+                           #   circle
+sr        !dimensionless   # Solid angle which cuts off an area of the surface
+steradian sr               #   of the sphere equal to that of a square with
+                           #   sides of length equal to the radius of the
+                           #   sphere
 
 #
-# Some primitive non-SI units
+# A primitive non-SI unit
 #
 
-?? Basic unit of information (entropy).  The entropy in bits of a
-?? random variable over a finite alphabet is defined to be the sum of
-?? -p(i)*log2(p(i)) over the alphabet where p(i) is the probability
-?? that the random variable takes on the value i.
-bit       !
+bit       !      # Basic unit of information (entropy).  The entropy in bits
+                 #   of a random variable over a finite alphabet is defined
+                 #   to be the sum of -p(i)*log2(p(i)) over the alphabet where
+                 #   p(i) is the probability that the random variable takes
+                 #   on the value i.
 
-?? One international unit of a biological agent is the biological
-?? activity equivalent to a standard amount of a substance that
-?? represents the agent (its “reference preparation”). Agents that
-?? can be measured in international units are generally found in
-?? multiple forms (such as Vitamin A) and/or not meaningfully
-?? comparable in SI units like moles (such as prolactin).
-?? WHO TRS 932, Annex 2.
-IU                              !
-
-# XXX: conflates “biological activity” and “immunological activity” to
-# avoid a conflicting quantities warning; some biological agents have
-# more than one reference preparation and/or more than one type of
-# biological activity [WHO TRS 932 pp. 80–81], but it’s unclear how
-# we would map such agents to Rink’s substance/property model
-biological_activity             ? IU
-biological_activity_density     ? mass / biological_activity
+#
+# Currency: the primitive unit of currency is defined in currency.units. 
+# It is usually the US$ or the euro, but it is user selectable.  
+#
 
 ###########################################################################
 #                                                                         #
 # Prefixes (longer names must come first)                                 #
 #                                                                         #
 ###########################################################################
-
-#!category prefixes "Prefixes"
 
 yotta-                  1e24     # Greek or Latin octo, "eight"
 zetta-                  1e21     # Latin septem, "seven"
@@ -255,10 +462,10 @@ atto-                   1e-18    # Danish-Norwegian atten, "eighteen"
 zepto-                  1e-21    # Latin septem, "seven"
 yocto-                  1e-24    # Greek or Latin octo, "eight"
 
-quarter--               1|4
-semi--                  0.5
-demi--                  0.5
-hemi--                  0.5
+quarter-                1|4
+semi-                   0.5
+demi-                   0.5
+hemi-                   0.5
 half-                   0.5
 double-                 2
 triple-                 3
@@ -270,41 +477,37 @@ gibi-                   2^30     # powers of two, the International
 tebi-                   2^40     # Electrotechnical Commission aproved these
 pebi-                   2^50     # binary prefixes for use in 1998.  If you
 exbi-                   2^60     # want to refer to "megabytes" using the
-Ki--                    kibi     # binary definition, use these prefixes.
-Mi--                    mebi
-Gi--                    gibi
-Ti--                    tebi
-Pi--                    pebi
-Ei--                    exbi
+Ki-                     kibi     # binary definition, use these prefixes.
+Mi-                     mebi
+Gi-                     gibi
+Ti-                     tebi
+Pi-                     pebi
+Ei-                     exbi
 
-Y--                     yotta
-Z--                     zetta
-E--                     exa
-P--                     peta
-T--                     tera
-G--                     giga
-M--                     mega
-k--                     kilo
-h--                     hecto
-da--                    deka
-d--                     deci
-c--                     centi
-m--                     milli
-u--                     micro   # it should be a mu but u is easy to type
-n--                     nano
-p--                     pico
-f--                     femto
-a--                     atto
-z--                     zepto
-y--                     yocto
-
-#!endcategory
+Y-                      yotta
+Z-                      zetta
+E-                      exa
+P-                      peta
+T-                      tera
+G-                      giga
+M-                      mega
+k-                      kilo
+h-                      hecto
+da-                     deka
+d-                      deci
+c-                      centi
+m-                      milli
+u-                      micro   # it should be a mu but u is easy to type
+n-                      nano
+p-                      pico
+f-                      femto
+a-                      atto
+z-                      zepto
+y-                      yocto
 
 #
 # Names of some numbers
 #
-
-!category numbers "Numbers"
 
 one                     1
 two                     2
@@ -342,7 +545,16 @@ hundred                 100
 thousand                1000
 million                 1e6
 
-!endcategory
+twoscore                two score
+threescore              three score
+fourscore               four score
+fivescore               five score
+sixscore                six score
+sevenscore              seven score
+eightscore              eight score
+ninescore               nine score
+tenscore                ten score
+twelvescore             twelve score
 
 # These number terms were described by N. Chuquet and De la Roche in the 16th
 # century as being successive powers of a million.  These definitions are still
@@ -350,8 +562,6 @@ million                 1e6
 # numbers arose in the 17th century and don't make nearly as much sense.  These
 # numbers are listed in the CRC Concise Encyclopedia of Mathematics by Eric
 # W. Weisstein.
-
-!category short_system "Short System"
 
 shortbillion               1e9
 shorttrillion              1e12
@@ -374,12 +584,8 @@ shortoctodecillion         1e57
 shortnovemdecillion        1e60
 shortvigintillion          1e63
 
-!endcategory
-
 centillion              1e303
 googol                  1e100
-
-!category long_system "Long System"
 
 longbillion               million^2
 longtrillion              million^3
@@ -430,8 +636,6 @@ longnonilliard            nonilliard
 longnoventilliard         noventilliard
 longdecilliard            decilliard
 
-!endcategory
-
 # The long centillion would be 1e600.  The googolplex is another
 # familiar large number equal to 10^googol.  These numbers give overflows.
 
@@ -461,7 +665,7 @@ novemdecillion          shortnovemdecillion
 vigintillion            shortvigintillion
 
 #
-# Numbers used in India
+# Numbers used in India 
 #
 
 lakh                    1e5
@@ -484,8 +688,6 @@ shankh                  1e17
 # Named SI derived units (officially accepted)
 #
 
-!category si_derived "SI Derived Units"
-
 newton                  kg m / s^2   # force
 N                       newton
 pascal                  N/m^2        # pressure or stress
@@ -505,14 +707,12 @@ farad                   C/V          # capacitance
 F                       farad
 weber                   V s          # magnetic flux
 Wb                      weber
-henry                   Wb/A         # inductance
+henry                   V s / A      # inductance
 H                       henry
 tesla                   Wb/m^2       # magnetic flux density
 T                       tesla
 hertz                   /s           # frequency
 Hz                      hertz
-
-!endcategory
 
 #
 # Dimensions.  These are here to help with dimensional analysis and
@@ -520,71 +720,60 @@ Hz                      hertz
 # "You want:" prompt to tell the user the dimension of the unit.
 #
 
-dimensionless           ? 1
-length                  ? meter
-area                    ? length^2
-volume                  ? length^3
-mass                    ? kilogram
-current                 ? ampere
-amount                  ? mole
-angle                   ? radian
-solid_angle             ? steradian
-force                   ? newton
-pressure                ? pascal
-stress                    pascal
-charge                  ? coulomb
-capacitance             ? farad
-resistance              ? ohm
-conductance             ? siemens
-inductance              ? henry
-frequency               ? hertz
-velocity                ? length / time
-acceleration            ? velocity / time
-jerk                    ? acceleration / time
-snap                    ? jerk / time
-crackle                 ? snap / time
-pop                     ? crackle / time
-density                 ? mass / volume
-linear_density          ? mass / length
-viscosity               ? pressure time
-kinematic_viscosity     ? viscosity / density
-magnetic_flux           ? weber
-magnetic_flux_density   ? tesla
-magnetization           ? current / length
-electrical_potential    ? volt
-electric_field          ? newton / coulomb
-entropy                 ? energy / temperature
-thermal_inductance      ? energy temperature^2 / power^2
-permittivity            ? farad / meter
-permeability            ? henry / meter
-angular_momentum        ? mass area / time
-area_density            ? mass / area
-catalytic_activity      ? amount / time
-chemical_potential      ? energy / amount
-molar_concentration     ? amount / volume
-current_density         ? current / area
-electric_charge_density ? charge / volume
-electric_displacement   ? charge / area
-impulse                 ? mass length / time
-heat_flux_density       ? power / area
-molar_entropy           ? entropy / amount
-moment_of_inertia       ? mass area
-reaction_rate           ? amount / volume time
-specific_heat_capacity  ? energy / mass temperature
-specific_volume         ? volume / mass
-surface_tension         ? energy / area
-fuel_efficiency         ? area^-1
-specific_energy         ? energy / mass
-molar_mass              ? mass / amount
-flow_rate               ? volume / time
-pressure_column         ? pressure / length
-
+LENGTH                  meter
+AREA                    LENGTH^2
+VOLUME                  LENGTH^3
+MASS                    kilogram
+AMOUNT                  mole
+ANGLE                   radian
+SOLID_ANGLE             steradian
+MONEY                   US$
+FORCE                   newton
+PRESSURE                FORCE / AREA
+STRESS                  FORCE / AREA
+FREQUENCY               hertz
+VELOCITY                LENGTH / TIME
+ACCELERATION            VELOCITY / TIME
+DENSITY                 MASS / VOLUME
+LINEAR_DENSITY          MASS / LENGTH
+VISCOSITY               FORCE TIME / AREA
+KINEMATIC_VISCOSITY     VISCOSITY / DENSITY
+CURRENT                 ampere
+CHARGE                  coulomb
+CAPACITANCE             farad
+RESISTANCE              ohm
+CONDUCTANCE             siemens
+# It may be easier to understand the relationship by considering
+# an object with specified dimensions and resistivity, whose
+# resistance is given by the resistivity * length / area. 
+RESISTIVITY             RESISTANCE AREA / LENGTH
+CONDUCTIVITY            CONDUCTANCE LENGTH / AREA
+INDUCTANCE              henry
+E_FIELD                 ELECTRIC_POTENTIAL / LENGTH
+B_FIELD                 tesla
+# The D and H fields are related to the E and B fields by factors of
+# epsilon and mu respectively, so their units can be found by
+# multiplying/dividing by the epsilon0 and mu0.  The more complex
+# definitions below make it possible to use D_FIELD and E_FIELD to
+# convert between SI and CGS units for these dimensions.
+D_FIELD                 E_FIELD epsilon0 / epsilon0_SI  #   mu0_SI c^2 F / m
+H_FIELD                 B_FIELD / (mu0/mu0_SI)
+ELECTRIC_DIPOLE_MOMENT  C m
+MAGNETIC_DIPOLE_MOMENT  J / T
+POLARIZATION            ELECTRIC_DIPOLE_MOMENT / VOLUME
+MAGNETIZATION           MAGNETIC_DIPOLE_MOMENT / VOLUME
+ELECTRIC_POTENTIAL      ENERGY / CHARGE #volt
+VOLTAGE                 ELECTRIC_POTENTIAL
+E_FLUX                  E_FIELD AREA	
+D_FLUX                  D_FIELD AREA
+B_FLUX                  B_FIELD AREA	
+H_FLUX                  H_FIELD AREA
 
 #
 # units derived easily from SI units
 #
 
-gram                    1|1000 kg
+gram                    millikg
 gm                      gram
 g                       gram
 tonne                   1000 kg
@@ -595,7 +784,7 @@ funal                   sthene
 pieze                   sthene / m^2
 quintal                 100 kg
 bar                     1e5 Pa     # About 1 atm
-#b                       bar
+b                       bar
 vac                     millibar
 micron                  micrometer # One millionth of a meter
 bicron                  picometer  # One brbillionth of a meter
@@ -623,7 +812,16 @@ xunit_mo             1.00209952e-13 m # degC.  It was intended to be exactly
                                       # reference to common x-ray lines, either
                                       # the K-alpha 1 line of copper or the
                                       # same line of molybdenum.
-angstromstar            1.00001495 angstrom # Defined by JA Bearden in 1965
+angstromstar   1.00001495 angstrom # Defined by JA Bearden in 1965 to replace 
+                                   #   the X unit.  The wavelength of the
+                                   #   tungsten K alpha1 line was defined as
+                                   #   exactly 0.20901 angstrom star, with the
+                                   #   valule chosen to try to make the new
+                                   #   unit close to the angstrom.  
+silicon_d220     1.920155716e-10 m # Silicon lattice spacing
+siliconlattice sqrt(8) silicon_d220# Silicon lattice parameter, (a), the side
+                                   #   length of the unit cell for the diamond
+                                   #   centered cubic structure of silicon.
 fermi                   1e-15 m    # Convenient for describing nuclear sizes
                                    #   Nuclear radius is from 1 to 10 fermis
 barn                    1e-28 m^2  # Used to measure cross section for
@@ -672,6 +870,13 @@ pyron            cal_IT / cm^2 min # Measures heat flow from solar radiation,
 katal                   mol/sec    # Measure of the amount of a catalyst.  One
 kat                     katal      #   katal of catalyst enables the reaction
                                    #   to consume or produce on mol/sec.
+solarluminosity         382.8e24 W # A common yardstick for comparing the
+                                   #   output of different stars.
+                # http://nssdc.gsfc.nasa.gov/planetary/factsheet/sunfact.html
+# at mean earth-sun distance
+solarirradiance		solarluminosity / (4 pi sundist^2)
+solarconstant		solarirradiance
+TSI			solarirradiance		# total solar irradiance
 
 #
 # time
@@ -682,7 +887,6 @@ minute                  60 s
 min                     minute
 hour                    60 min
 hr                      hour
-h                       hour
 day                     24 hr
 d                       day
 da                      day
@@ -702,9 +906,9 @@ bell                    1|8 watch  # Bell would be sounded every 30 minutes.
 # on.  In 1998 Swatch defined a time measurement called ".beat" and
 # sold some watches that displayed time in this unit.
 
-decimalhour             1|10 day
-decimalminute           1|100 decimalhour
-decimalsecond           1|100 decimalminute
+decimalhour             1|10 day            
+decimalminute           1|100 decimalhour   
+decimalsecond           1|100 decimalminute 
 beat                    decimalminute          # Swatch Internet Time
 
 #
@@ -720,8 +924,8 @@ arcminute               arcmin
 '                       arcmin
 arcsec                  1|60 arcmin
 arcsecond               arcsec
-#"                       arcsec
-#''                      "
+"                       arcsec
+''                      "
 rightangle              90 degrees
 quadrant                1|4 circle
 quintant                1|5 circle
@@ -750,11 +954,11 @@ seclongitude            circle (seconds/day) # Astronomers measure longitude
 # Some geometric formulas
 #
 
-#circlearea(r)   units=[m;m^2] range=[0,) pi r^2 ; sqrt(circlearea/pi)
-#spherevolume(r) units=[m;m^3] range=[0,) 4|3 pi r^3 ; \
-#                                         cuberoot(spherevolume/4|3 pi)
-#spherevol()     spherevolume
-#square(x)       range=[0,)          x^2 ; sqrt(square)
+circlearea(r)   units=[m;m^2] range=[0,) pi r^2 ; sqrt(circlearea/pi)
+spherevolume(r) units=[m;m^3] range=[0,) 4|3 pi r^3 ; \
+                                         cuberoot(spherevolume/4|3 pi)
+spherevol()     spherevolume
+square(x)       range=[0,)          x^2 ; sqrt(square)
 
 #
 # Solid angle measure
@@ -772,8 +976,6 @@ octant                  0.5 pi sr
 #
 # Concentration measures
 #
-
-!category concentrations "Concentrations"
 
 percent                 0.01
 %                       percent
@@ -799,13 +1001,11 @@ gammil                  mg/l
 basispoint              0.01 %    # Used in finance
 fine                    1|1000    # Measure of gold purity
 
-!endcategory
-
 # The pH scale is used to measure the concentration of hydronium (H3O+) ions in
 # a solution.  A neutral solution has a pH of 7 as a result of dissociated
 # water molecules.
 
-#pH(x) units=[1;mol/liter] range=(0,) 10^(-x) mol/liter ; (-log(pH liters/mol))
+pH(x) units=[1;mol/liter] range=(0,) 10^(-x) mol/liter ; (-log(pH liters/mol))
 
 
 #
@@ -816,9 +1016,24 @@ fine                    1|1000    # Measure of gold purity
 # differences start with "deg" and conversions for absolute temperature start
 # with "temp".
 #
+# If the temperature inside is 72 degrees Fahrenheit and you want to
+# convert this to degrees Celsius then you need absolute temperature:
+#
+# You have: tempF(72)
+# You want: tempC
+#         22.222222
+#
+# If the temperature rose 72 degrees Fahrenheit during the chemical reaction
+# then this is a temperature difference:
+#
+# You have: 72 degF
+# You want: degC
+#        * 40
+#        / 0.025
+#
 
-temperature             ? kelvin
-temperature_difference  kelvin
+TEMPERATURE             kelvin
+TEMPERATURE_DIFFERENCE  kelvin
 
 # In 1741 Anders Celsius introduced a temperature scale with water boiling at
 # 0 degrees and freezing at 100 degrees at standard pressure. After his death
@@ -830,11 +1045,11 @@ temperature_difference  kelvin
 # centigrade definition, but the Kelvin scale depends on the triple point of
 # water rather than a melting point, so it can be measured accurately.
 
-#tempC(x) units=[1;K] domain=[-273.15,) range=[0,) \
-#                             x K + stdtemp ; (tempC +(-stdtemp))/K
-#tempcelsius() tempC
-#degcelsius              K
-#degC                    K
+tempC(x) units=[1;K] domain=[-273.15,) range=[0,) \
+                             x K + stdtemp ; (tempC +(-stdtemp))/K
+tempcelsius() tempC
+degcelsius              K
+degC                    K
 
 # Fahrenheit defined his temperature scale by setting 0 to the coldest
 # temperature he could produce in his lab with a salt water solution and by
@@ -848,33 +1063,23 @@ temperature_difference  kelvin
 #    is placed in the mouth so as to acquire the heat of a healthy
 #    man."  (D. G. Fahrenheit, Phil. Trans. (London) 33, 78, 1724)
 
-#tempF(x) units=[1;K] domain=[-459.67,) range=[0,) \
-#                (x+(-32)) degF + stdtemp ; (tempF+(-stdtemp))/degF + 32
-#tempfahrenheit() tempF
-#degfahrenheit           5|9 degC
-#degF                    5|9 degC
+tempF(x) units=[1;K] domain=[-459.67,) range=[0,) \
+                (x+(-32)) degF + stdtemp ; (tempF+(-stdtemp))/degF + 32
+tempfahrenheit() tempF
+degfahrenheit           5|9 degC
+degF                    5|9 degC
 
 
-degreesrankine          5|9 K             # The Rankine scale has the
+degreesrankine          degF              # The Rankine scale has the
 degrankine              degreesrankine    # Fahrenheit degree, but its zero
-degreerankine           degreesrankine    # is at absolute zero.
+degreerankine           degF              # is at absolute zero.
 degR                    degrankine
 tempR                   degrankine
 temprankine             degrankine
 
-reaumur_absolute        10|8 kelvin
-romer_absolute          40|21 kelvin
-delisle_absolute        -2|3 kelvin
-newton_absolute         100|33 kelvin
-
-zerocelsius             273.15 K
-zerofahrenheit          zerocelsius - 32 degR
-zerodelisle             373.15 kelvin
-zeroromer               zerocelsius - 7.5 romer_absolute
-
-#tempreaumur(x)    units=[1;K] domain=[-218.52,) range=[0,) \
-#                  x degreaumur+stdtemp ; (tempreaumur+(-stdtemp))/degreaumur
-#degreaumur              10|8 degC # The Reaumur scale was used in Europe and
+tempreaumur(x)    units=[1;K] domain=[-218.52,) range=[0,) \
+                  x degreaumur+stdtemp ; (tempreaumur+(-stdtemp))/degreaumur
+degreaumur              10|8 degC # The Reaumur scale was used in Europe and
                                   # particularly in France.  It is defined
                                   # to be 0 at the freezing point of water
                                   # and 80 at the boiling point.  Reaumur
@@ -895,23 +1100,46 @@ tempK                   K         # For consistency
 #
 # k_f = 275
 #
-#gasmark[degR] \
-#  .0625    634.67 \
-#  .125     659.67 \
-#  .25      684.67 \
-#  .5       709.67 \
-#  1        734.67 \
-#  2        759.67 \
-#  3        784.67 \
-#  4        809.67 \
-#  5        834.67 \
-#  6        859.67 \
-#  7        884.67 \
-#  8        909.67 \
-#  9        934.67 \
-#  10       959.67
+gasmark[degR] \
+  .0625    634.67 \
+  .125     659.67 \
+  .25      684.67 \
+  .5       709.67 \
+  1        734.67 \
+  2        759.67 \
+  3        784.67 \
+  4        809.67 \
+  5        834.67 \
+  6        859.67 \
+  7        884.67 \
+  8        909.67 \
+  9        934.67 \
+  10       959.67
 
-# Units cannot handle wind chill or heat index because they are two variable
+
+# The Beaufort wind force scale was developed from 1805-1807 by Sir Francis
+# Beaufort to categorize wind conditions at sea. It is normally defined from
+# Beaufort 0, also called "Force 0," through Beaufort 12. Beaufort numbers
+# 13-17 were later defined for tropical cyclones but are rarely used. The
+# original Beaufort scale was qualitative and did not relate directly to wind
+# speed. In 1906, George Simpson of the British Met Office fit wind-speed
+# measurements to visual Beaufort estimates made from five coastal and inland
+# stations in Britain. Simpson's formula was adopted by the World Meterological
+# Organization in 1946 to produce a table, known as WMO Code 1100, giving mean
+# (and min/max) wind speed equivalents at a height of 10 meters for each
+# Beaufort number. This is the "operational" Beaufort scale that mariners
+# use. Meterological and climatic researchers typically use a "scientific"
+# Beaufort scale based on more recent and comprehensive fits. See Wallbrink and
+# Cook, Historical Wind Speed Equivalents Of The Beaufort Scale, 1850-1950, at
+# https://icoads.noaa.gov/reclaim/pdf/Hisklim13.pdf
+#
+beaufort_WMO1100(B) units=[1;m/s] domain=[0,17] range=[0,) \
+                    0.836 B^3|2 m/s; (beaufort_WMO1100 s / 0.836 m)^2|3
+
+beaufort(B) units=[1;m/s] domain=[0,17] range=[0,) \
+            beaufort_WMO1100(B); ~beaufort_WMO1100(beaufort)
+
+# Units cannot handle wind chill or heat index because they are two-variable
 # functions, but they are included here for your edification.  Clearly these
 # equations are the result of a model fitting operation.
 #
@@ -939,63 +1167,68 @@ tempK                   K         # For consistency
 
 # Basic constants
 
-!category constants "Physical Constants"
-
-π                       3.14159265358979323846
-pi                      π
-τ                       2 pi
-tau                     τ
-c                       speed of light   # speed of light in vacuum (exact)
-#light                   c
-mu0                     4 pi 1e-7 H/m    # permeability of vacuum (exact)
-epsilon0                1/mu0 c^2        # permittivity of vacuum (exact)
-mass_energy             c^2              # convert mass to energy
-planck_constant         6.626070040e-34 J s
-hbar                    planck_constant / 2 pi
+pi                      3.14159265358979323846
+light                   c
+mu0_SI        2 alpha h_SI / e_SI^2 c_SI # Vacuum magnetic permeability
+mu0                    2 alpha h / e^2 c #   Gets overridden in CGS modes
+epsilon0_SI             1/mu0_SI c_SI^2  # Vacuum electric permittivity
+epsilon0                1/mu0 c^2        #   Also overridden in CGS modes
+Z0                      mu0 c            # Free space impedance
+energy                  c^2              # Convert mass to energy
+hbar                    h / 2 pi
+hbar_SI                 h_SI / 2 pi
 spin                    hbar
-G               6.67408e-11 N m^2 / kg^2 # Newtonian gravitational constant
-                                         #    This is the NIST 2006 value.
-                                         #    The relative uncertainty on this
-                                         #    is 1e-4.
-coulombconst            1/4 pi epsilon0  # listed as "k" sometimes
+G_SI            6.67430e-11
+G               6.67430e-11 N m^2 / kg^2 # Newtonian gravitational constant
+coulombconst            1/4 pi epsilon0  # Listed as k or k_C sometimes
+k_C                     coulombconst
 
 # Physico-chemical constants
 
-atomicmassunit        1.660539040e-27 kg # atomic mass unit (defined to be
-u                       atomicmassunit   #   1|12 of the mass of carbon 12)
-amu                     atomicmassunit
+atomicmassunit_SI   1.66053906660e-27    # Unified atomic mass unit, defined as
+atomicmassunit      1.66053906660e-27 kg # Unified atomic mass unit, defined as
+u                       atomicmassunit   #   1|12 of the mass of carbon 12.
+amu                     atomicmassunit   #   The relationship N_A u = 1 g/mol
+dalton                  u                #   is approximately, but not exactly 
+Da                      dalton           #   true (with the 2019 SI).
+                                         #   Previously the mole was defined to
+                                         #   make this relationship exact.
 amu_chem                1.66026e-27 kg   # 1|16 of the weighted average mass of
                                          #   the 3 naturally occuring neutral
                                          #   isotopes of oxygen
 amu_phys                1.65981e-27 kg   # 1|16 of the mass of a neutral
                                          #   oxygen 16 atom
-dalton                  u                # Maybe this should be amu_chem?
-avogadro                grams/amu mol    # size of a mole
-N_A                     avogadro
-gasconstant             boltzmann N_A    # molar gas constant
+gasconstant             k N_A            # Molar gas constant (exact)
 R                       gasconstant
-boltzmann             1.38064852e-23 J/K # Boltzmann constant
-#k                       boltzmann
 kboltzmann              boltzmann
 molarvolume         mol R stdtemp / atm  # Volume occupied by one mole of an
                                          #   ideal gas at STP.
 loschmidt     avogadro mol / molarvolume # Molecules per cubic meter of an
                                          #   ideal gas at STP.  Loschmidt did
                                          #   work similar to Avogadro.
-stefanboltzmann pi^2 boltzmann^4 / 60 hbar^3 c^2 # The power per area radiated by a
+molarvolume_si  N_A siliconlattice^3 / 8 # Volume of a mole of crystalline
+                                         #   silicon. The unit cell contains 8
+                                         #   silicon atoms and has a side
+                                         #   length of siliconlattice.
+stefanboltzmann pi^2 k^4 / 60 hbar^3 c^2 # The power per area radiated by a
 sigma                   stefanboltzmann  #   blackbody at temperature T is
-                                         #   given by sigma T^4.
-wiendisplacement        2.8977729e-3 m K # Wien's Displacement Law gives the
-                                         #   frequency at which the the Planck
-                                         #   spectrum has maximum intensity.
-                                         #   The relation is lambda T = b where
-                                         #   lambda is wavelength, T is
-                                         #   temperature and b is the Wien
+                                         #   given by sigma T^4. (exact)
+wiendisplacement     (h c/k)/4.9651142317442763  # Wien's Displacement Law gives
+                                         #   the frequency at which the the
+                                         #   Planck spectrum has maximum
+                                         #   intensity.  The relation is lambda
+                                         #   T = b where lambda is wavelength,
+                                         #   T is temperature and b is the Wien
                                          #   displacement.  This relation is
                                          #   used to determine the temperature
-                                         #   of stars.
+                                         #   of stars.  The constant is the
+                                         #   solution to x=5(1-exp(-x)).
+                                         #   This expression has no experimental
+                                         #   error, and x is defined exactly
+                                         #   by the equation above, so it is
+                                         #   an exact definition.  
 K_J90 483597.9 GHz/V    # Direct measurement of the volt is difficult.  Until
-K_J   483597.8525 GHz/V #   recently, laboratories kept Weston cadmium cells as
+K_J   2e/h              #   recently, laboratories kept Weston cadmium cells as
                         #   a reference, but they could drift.  In 1987 the
                         #   CGPM officially recommended the use of the
                         #   Josephson effect as a laboratory representation of
@@ -1005,12 +1238,12 @@ K_J   483597.8525 GHz/V #   recently, laboratories kept Weston cadmium cells as
                         #   with a frequency that depends on the potential
                         #   applied across the superconductors.  This frequency
                         #   can be very accurately measured.  The Josephson
-                        #   constant K_J, which is equal to 2e/h, relates the
-                        #   measured frequency to the potential.  Two values
-                        #   given, the conventional (exact) value from 1990 and
-                        #   the current CODATA measured value.
+                        #   constant K_J relates the measured frequency to the
+                        #   potential.  Two values given, the conventional
+                        #   (exact) value from 1990, which was used until the
+                        #   2019 SI revision, and the current exact value.
 R_K90 25812.807 ohm     # Measurement of the ohm also presents difficulties.
-R_K   25812.8074555 ohm #   The old approach involved maintaining resistances
+R_K   h/e^2             #   The old approach involved maintaining resistances
                         #   that were subject to drift.  The new standard is
                         #   based on the Hall effect.  When a current carrying
                         #   ribbon is placed in a magnetic field, a potential
@@ -1021,9 +1254,25 @@ R_K   25812.8074555 ohm #   The old approach involved maintaining resistances
                         #   in discrete jumps when the magnetic field is very
                         #   large and the temperature very low.  This enables
                         #   accurate realization of the resistance h/e^2 in the
-                        #   lab.  Two values given, the conventional (exact)
-                        #   value from 1990 and the current CODATA measured
-                        #   value.
+                        #   lab.  The 1990 value was an exact conventional 
+                        #   value used until the SI revision in 2019. This value
+                        #   did not agree with measurements.  The new value
+                        #   is exact.
+
+# The 2019 update to SI gives exact definitions for R_K and K_J.  Previously
+# the electromagnetic units were realized using the 1990 conventional values
+# for these constants, and as a result, the standard definitions were in some
+# sense outside of SI.  The revision corrects this problem.  The definitions
+# below give the 1990 conventional values for the electromagnetic units in
+# terms of 2019 SI.  
+
+ampere90 (K_J90 R_K90 / K_J R_K) A
+coulomb90 (K_J90 R_K90 / K_J R_K) C
+farad90 (R_K90/R_K) F
+henry90 (R_K/R_K90) H
+ohm90 (R_K/R_K90) ohm
+volt90 (K_J90/K_J) V
+watt90 (K_J90^2 R_K90 / K_J^2 R_K) W
 
 # Various conventional values
 
@@ -1031,52 +1280,131 @@ gravity                 9.80665 m/s^2    # std acceleration of gravity (exact)
 force                   gravity          # use to turn masses into forces
 atm                     101325 Pa        # Standard atmospheric pressure
 atmosphere              atm
+Hg             13.5951 gram force / cm^3 # Standard weight of mercury (exact)
+water                   gram force/cm^3  # Standard weight of water (exact)
+waterdensity            gram / cm^3      # Density of water
+H2O                     water
+wc                      water            # water column
 mach                    331.46 m/s       # speed of sound in dry air at STP
 standardtemp            273.15 K         # standard temperature
 stdtemp                 standardtemp
-normaltemp              529.67 degR      # for gas density, from NIST
+normaltemp              tempF(70)        # for gas density, from NIST
 normtemp                normaltemp       # Handbook 44
+
+# Weight of mercury and water at different temperatures using the standard
+# force of gravity.
+
+Hg10C         13.5708 force gram / cm^3  # These units, when used to form
+Hg20C         13.5462 force gram / cm^3  # pressure measures, are not accurate
+Hg23C         13.5386 force gram / cm^3  # because of considerations of the
+Hg30C         13.5217 force gram / cm^3  # revised practical temperature scale.
+Hg40C         13.4973 force gram / cm^3
+Hg60F         13.5574 force gram / cm^3
+H2O0C         0.99987 force gram / cm^3
+H2O5C         0.99999 force gram / cm^3
+H2O10C        0.99973 force gram / cm^3
+H2O15C        0.99913 force gram / cm^3
+H2O18C        0.99862 force gram / cm^3
+H2O20C        0.99823 force gram / cm^3
+H2O25C        0.99707 force gram / cm^3
+H2O50C        0.98807 force gram / cm^3
+H2O100C       0.95838 force gram / cm^3
 
 # Atomic constants
 
-Rinfinity            10973731.568539 /m  # The wavelengths of a spectral series
+
+
+Rinfinity            m_e c alpha^2 / 2 h # The wavelengths of a spectral series
 R_H                     10967760 /m      #   can be expressed as
                                          #     1/lambda = R (1/m^2 - 1/n^2).
                                          #   where R is a number that various
                                          #   slightly from element to element.
                                          #   For hydrogen, R_H is the value,
                                          #   and for heavy elements, the value
-                                         #   approaches Rinfinity, which can be
-                                         #   computed from
-                                         #        m_e c alpha^2 / 2 h
-                                         #   with a loss of 4 digits
-                                         #   of precision.
-alpha                   7.2973525664e-3  # The fine structure constant was
+                                         #   approaches Rinfinity. 
+alpha                    7.2973525693e-3 # The fine structure constant was
                                          #   introduced to explain fine
                                          #   structure visible in spectral
-                                         #   lines.  It can be computed from
-                                         #         mu0 c e^2 / 2 h
-                                         #   with a loss of 3 digits precision
-                                         #   and loss of precision in derived
-                                         #   values which use alpha.
+                                         #   lines.  
 bohrradius              alpha / 4 pi Rinfinity
 prout                   185.5 keV        # nuclear binding energy equal to 1|12
                                          #   binding energy of the deuteron
-# Planck constants
+conductancequantum      2 e^2 / h
 
-planckmass              2.17651e-8 kg     # sqrt(hbar c / G)
-m_P                     planckmass
-plancktime              hbar / planckmass c^2
-t_P                     plancktime
-plancklength            plancktime c
-l_P                     plancklength
 
-# Magnetic moments
+# Particle radius
 
-bohrmagneton            electroncharge hbar / mass of 2 electron
-mu_B                    bohrmagneton
-nuclearmagneton         electroncharge hbar / mass of 2 proton
-mu_N                    nuclearmagneton
+electronradius    coulombconst e^2 / electronmass c^2   # Classical
+deuteronchargeradius    2.12799e-15 m
+protonchargeradius      0.8751e-15 m
+
+# Masses of elementary particles
+
+electronmass_SI         electronmass_u atomicmassunit_SI
+electronmass_u          5.48579909065e-4
+electronmass            5.48579909065e-4 u
+m_e                     electronmass
+muonmass                0.1134289259 u
+m_mu                    muonmass
+taumass                 1.90754 u
+m_tau                   taumass
+protonmass              1.007276466621 u
+m_p                     protonmass
+neutronmass             1.00866491595 u
+m_n                     neutronmass
+deuteronmass            2.013553212745 u    # Nucleus of deuterium, one
+m_d                     deuteronmass        #   proton and one neutron
+alphaparticlemass       4.001506179127 u    # Nucleus of He, two protons
+m_alpha                 alphaparticlemass   #   and two neutrons
+tritonmass              3.01550071621 u     # Nucleius of H3, one proton
+m_t                     tritonmass          #   and two neutrons
+helionmass              3.014932247175 u    # Nucleus of He3, two protons
+m_h                     helionmass          #   and one neutron
+
+# particle wavelengths: the compton wavelength of a particle is
+# defined as h / m c where m is the mass of the particle.
+
+electronwavelength      h / m_e c
+lambda_C                electronwavelength
+protonwavelength        h / m_p c
+lambda_C,p              protonwavelength
+neutronwavelength       h / m_n c
+lambda_C,n              neutronwavelength
+muonwavelength          h / m_mu c
+lambda_C,mu             muonwavelength
+
+# The g-factor or dimensionless magnetic moment is a quantity that
+# characterizes the magnetic moment of a particle.  The electron g-factor is
+# one of the most precisely measured values in physics, with a relative
+# uncertainty of 1.7e-13.  
+
+g_d                     0.8574382338       # Deuteron g-factor
+g_e                    -2.00231930436256   # Electron g-factor
+g_h                    -4.255250615        # Helion g-factor
+g_mu                   -2.0023318418       # Muon g-factor
+g_n                    -3.82608545         # Neutron g-factor
+g_p                     5.5856946893       # Proton g-factor
+g_t                     5.957924931        # Triton g-factor
+
+fermicoupling           1.1663787e-5 / GeV^2
+
+# Magnetic moments (derived from the more accurate g-factors)
+#
+# The magnetic moment is g * mu_ref * spin where in most cases
+# the reference is the nuclear magneton, and all of the particles
+# except the deuteron have spin 1/2.  
+
+bohrmagneton            e hbar / 2 electronmass  # Reference magnetic moment for
+mu_B                    bohrmagneton             #   the electron
+nuclearmagneton         e hbar /  2 protonmass   # Convenient reference magnetic
+mu_N                    nuclearmagneton          #   moment for heavy particles
+mu_e                    g_e mu_B / 2             # Electron spin magnet moment
+mu_mu                   g_mu e hbar / 4 muonmass # Muon spin magnetic moment
+mu_p                    g_p mu_N / 2             # Proton magnetic moment
+mu_n                    g_n mu_N / 2             # Neutron magnetic moment
+mu_t                    g_t mu_N / 2             # Triton magnetic moment
+mu_d                    g_d mu_N            # Deuteron magnetic moment, spin 1
+mu_h                    g_h mu_N / 2             # Helion magnetic moment
 
 #
 # Units derived from physical constants
@@ -1086,47 +1414,47 @@ kgf                     kg force
 technicalatmosphere     kgf / cm^2
 at                      technicalatmosphere
 hyl                     kgf s^2 / m   # Also gram-force s^2/m according to [15]
-torr                    atm / 760  # These units, both named after Evangelista
-tor                     Pa         # Torricelli, should not be confused.  The
-eV                      electroncharge V # Energy acquired by a particle with charge e
+mmHg                    mm Hg
+torr                    atm / 760  # The torr, named after Evangelista
+                                   # Torricelli, and is very close to the mm Hg
+tor                     Pa         # Suggested in 1913 but seldom used [24].
+                                   # Eventually renamed the Pascal.  Don't 
+                                   # confuse the tor with the torr.  
+inHg                    inch Hg    
+inH2O                   inch water
+mmH2O                   mm water
+eV                      e V      # Energy acquired by a particle with charge e
 electronvolt            eV       #   when it is accelerated through 1 V
 lightyear               c julianyear # The 365.25 day year is specified in
 ly                      lightyear    # NIST publication 811
 lightsecond             c s
 lightminute             c min
-parsec                  32313140071200 km
-pc                      parsec
-#parsec                  au / tan(arcsec)    # Unit of length equal to distance
-#pc                      parsec              #   from the sun to a point having
+parsec                  au / tan(arcsec)    # Unit of length equal to distance
+pc                      parsec              #   from the sun to a point having
                                             #   heliocentric parallax of 1
                                             #   arcsec (derived from parallax
                                             #   second).  A distant object with
-                                            #   paralax theta will be about
+                                            #   parallax theta will be about
                                             #   (arcsec/theta) parsecs from the
                                             #   sun (using the approximation
                                             #   that tan(theta) = theta).
-rydberg                 planck_constant c Rinfinity # Rydberg energy
+rydberg                 h c Rinfinity       # Rydberg energy
 crith                   0.089885 gram       # The crith is the mass of one
                                             #   liter of hydrogen at standard
                                             #   temperature and pressure.
 amagatvolume            molarvolume
 amagat                  mol/amagatvolume    # Used to measure gas densities
-lorentz                 bohrmagneton / planck_constant c # Used to measure the extent
+lorentz                 bohrmagneton / h c  # Used to measure the extent
                                             #   that the frequency of light
                                             #   is shifted by a magnetic field.
-cminv                   planck_constant c / cm # Unit of energy used in infrared
+cminv                   h c / cm            # Unit of energy used in infrared
 invcm                   cminv               #   spectroscopy.
 wavenumber              cminv
 kcal_mol                kcal_th / mol N_A   # kcal/mol is used as a unit of
                                             #   energy by physical chemists.
-
-!endcategory
-
 #
 # CGS system based on centimeter, gram and second
 #
-
-!category cgs "CGS Units"
 
 dyne                    cm gram / s^2   # force
 dyn                     dyne
@@ -1154,13 +1482,11 @@ pond                    gram force
 glug                gram force s^2 / cm # Mass which is accelerated at
                                         #   1 cm/s^2 by 1 gram force
 darcy           centipoise cm^2 / s atm # Measures permeability to fluid flow.
-
                                         #   One darcy is the permeability of a
                                         #   medium that allows a flow of cc/s
                                         #   of a liquid of centipoise viscosity
                                         #   under a pressure gradient of
                                         #   atm/cm.  Named for H. Darcy.
-
 mobileohm               cm / dyn s      # mobile ohm, measure of mechanical
                                         #   mobility
 mechanicalohm           dyn s / cm      # mechanical resistance
@@ -1171,60 +1497,428 @@ ray                     acousticalohm
 rayl                    dyn s / cm^3    # Specific acoustical resistance
 eotvos                  1e-9 Gal/cm     # Change in gravitational acceleration
                                         #   over horizontal distance
+#
+# Electromagnetic CGS Units
+# 
+# For measuring electromagnetic quantities in SI, we introduce the new base
+# dimension of current, define the ampere to measure current, and derive the
+# other electromagnetic units from the ampere.  With the CGS units one approach
+# is to use the basic equations of electromagnetism to define units that
+# eliminate constants from those equations.  Coulomb's law has the form
+#
+#          F = k_C q1 q2 / r^2
+#
+# where k_C is the Coulomb constant equal to 1|4 pi epsilon0 in SI units.
+# Ampere's force law takes the form
+#
+#          dF/dl = 2 k_A I1 I2 / r
+#
+# where k_A is the ampere constant.  In the CGS system we force either k_C or
+# k_A to 1 which then defines either a unit for charge or a unit for current.
+# The other unit then becomes a derived unit.  When k_C is 1 the ESU system
+# results.  When k_A is 1 the EMU system results.  Note that these parameters
+# are not independent of each other: Maxwell's equations indicate that
+#         
+#           k_C / k_A = c^2
+#
+# where c is the speed of light. 
+#
+# One more choice is needed to define a complete system.  Using Coulomb's law
+# we define the electric field as the force per unit charge
+#
+#           E = k_C 1 / r^2.
+#
+# But what about the magnetic field?  It is derived from Ampere's law but we
+# have the option of adding a proportionality constant, k_B, that may have
+# dimensions:
+#
+#           B = 2 k_A k_B I / r
+#
+# We can choose k_B = 1, which is done in the SI, ESU and EMU systems.  But if
+# instead we give k_B units of length/time then the magnetic field has
+# the same units as the electric field.  This choice leads to the Gaussian
+# and Heaviside-Lorentz systems.
+#
+# The relations above are used to determine the dimensions, but the units are
+# derived from the base units of CGS, not directly from those formulas.  We
+# will use the notation [unit] to refer to the dimension of the unit in
+# brackets.  This same process gives rise to the SI units such as the tesla, 
+# which is defined by
+#
+#         [tesla] = [2 (1/4 pi c^2 epsilon0) amp / m] = [(mu0 / 2) amp / m]
+#
+# which gives kg / A s^2 as expected.  
+#
+# References:
+#
+# Classical Electrodynamics by John David Jackson, 3rd edition. 
+# Cardarelli, Francois. 1999.  Scientific Unit Conversion. 2nd ed.  Trans.
+#     M.J.  Shields.  London: Springer-Verlag. ISBN 1-85233-043-0
+#
+#
+# All of the CGS systems result in electromagnetic units that involve the square
+# roots of the centimeter and gram.  This requires a change in the primitive
+# units.
+# 
 
-# Electromagnetic units derived from the abampere
+!var UNITS_SYSTEM esu emu gaussian gauss hlu
+sqrt_cm                 ! 
+sqrt_centimeter         sqrt_cm
++m                      100 sqrt_cm^2
+sqrt_g                  !
+sqrt_gram               sqrt_g
++kg                     kilo sqrt_g^2
+!endvar
+
+# Electrostatic CGS (ESU)
+#
+# This system uses the statcoulomb as the fundamental unit of charge, with
+# derived units that parallel the conventional terminology but use the stat-
+# prefix.  The statcoulomb is designed by setting k_C=1, which means
+#
+#                      dyne = statcoulomb^2 / cm^2. 
+#
+# The statcoulomb is also called the franklin or esu.
+#
+# The ESU system was specified by a committee report in 1873 and rarely used.
+
+statcoulomb             10 coulomb cm / s c   # Charge such that two charges 
+esu                     statcoulomb           # of 1 statC separated by 1 cm
+statcoul                statcoulomb           # exert a force of 1 dyne
+statC                   statcoulomb
+stC                     statcoulomb
+franklin                statcoulomb
+Fr                      franklin
+
+!var UNITS_SYSTEM esu
+!message CGS-ESU units selected
+!prompt (ESU)
++statcoulomb            sqrt(dyne) cm
++A                      10 c_SI statamp
++mu0                    1/c^2
++coulombconst           1
+!endvar
+
+statampere              statcoulomb / s
+statamp                 statampere
+statA                   statampere
+stA                     statampere
+statvolt                dyne cm / statamp sec
+statV                   statvolt
+stV                     statvolt
+statfarad               statamp sec / statvolt
+statF                   statfarad
+stF                     statfarad
+cmcapacitance           statfarad
+stathenry               statvolt sec / statamp
+statH                   stathenry
+stH                     stathenry
+statohm                 statvolt / statamp
+stohm                   statohm
+statmho                 /statohm
+stmho                   statmho
+statweber               statvolt sec
+statWb                  statweber
+stWb                    statweber
+stattesla               statWb/cm^2   # Defined by analogy with SI; rarely
+statT                   stattesla     #   if ever used
+stT                     stattesla
+debye                   1e-10 statC angstrom # unit of electrical dipole moment
+helmholtz               debye/angstrom^2     # Dipole moment per area
+jar                     1000 statfarad       # approx capacitance of Leyden jar
+
+# Electromagnetic CGS (EMU)
+#
+# The abampere is the fundamental unit of this system, with the derived units
+# using the ab- prefix.  The dimensions of the abampere are defined by assuming
+# that k_A=1, which 
+#
+#            [dyne / cm]  = [2 abampere^2 / cm]
+#
+# where the brackets indicate taking the dimension of the unit in base units
+# and discarding any constant factors.  This results in the definition from
+# base CGS units of:
+#
+#            abampere = sqrt(dyne). 
+#
+# The abampere is also called the biot.  The magnetic field unit (the gauss)
+# follows from the assumption that k_B=1, which means
+#
+#            B = 2 I / r,
+#
+# and hence the dimensions of the gauss are given by
+#
+#            [gauss] = [2 abampere / cm]
+#
+# or rewriting in terms of the base units
+#
+#            gauss = abampere / cm.
+#
+# The definition given below is different because it is in a form that
+# gives a valid reduction for SI and ESU and still gives the correct 
+# result in EMU.  (It can be derived from Faraday's law.)  
+#
+# The EMU system was developed by Gauss and Weber and formalized as a system in
+# a committee report by the British Association for the Advancement of Science
+# in 1873.  
 
 abampere                10 A            # Current which produces a force of
 abamp                   abampere        #   2 dyne/cm between two infinitely
 aA                      abampere        #   long wires that are 1 cm apart
-biot                    aA              # alternative name for abamp
+abA                     abampere
+biot                    abampere
 Bi                      biot
+
+!var UNITS_SYSTEM emu
+!message CGS-EMU units selected
+!prompt (EMU)
++abampere               sqrt(dyne)
++A                      0.1 abamp
++mu0                    1
++coulombconst           c^2
+!endvar
+
 abcoulomb               abamp sec
 abcoul                  abcoulomb
+abC                     abcoulomb
 abfarad                 abampere sec / abvolt
+abF                     abfarad
 abhenry                 abvolt sec / abamp
+abH                     abhenry
 abvolt                  dyne cm  / abamp sec
+abV                     abvolt
 abohm                   abvolt / abamp
 abmho                   /abohm
-gauss                   abvolt sec / cm^2
-Gs                      gauss
-maxwell                 abvolt sec      # Also called the "line"
+gauss                   abvolt sec / cm^2 # The magnetic field 2 cm from a wire
+Gs                      gauss             # carrying a current of 1 abampere
+maxwell                 gauss cm^2        # Also called the "line"
 Mx                      maxwell
-oersted                 gauss / mu0
-Oe                      oersted
+oersted                 gauss / mu0   # From the relation H = B / mu
+Oe                      oersted      
 gilbert                 gauss cm / mu0
+Gb                      gilbert
 Gi                      gilbert
-unitpole                4 pi maxwell
+unitpole                4 pi maxwell	# unit magnetic pole
 emu                     erg/gauss  # "electro-magnetic unit", a measure of
                                    # magnetic moment, often used as emu/cm^3
                                    # to specify magnetic moment density.
 
-# Gaussian system: electromagnetic units derived from statampere.
+# Electromagnetic CGS (Gaussian)
 #
-# Note that the Gaussian units are often used in such a way that Coulomb's law
-# has the form F= q1 * q2 / r^2.  The constant 1|4*pi*epsilon0 is incorporated
-# into the units.  From this, we can get the relation force=charge^2/dist^2.
-# This means that the simplification esu^2 = dyne cm^2 can be used to simplify
-# units in the Gaussian system, with the curious result that capacitance can be
-# measured in cm, resistance in sec/cm, and inductance in sec^2/cm.  These
-# units are given the names statfarad, statohm and stathenry below.
+# The Gaussian system uses the statcoulomb and statamp from the ESU system
+# derived by setting k_C=1, but it defines the magnetic field unit differently
+# by taking k_B=c instead of k_B=1.  As noted above, k_C and k_A are not
+# independent.  With k_C=1 we must have k_A=c^-2.  This results in the magnetic
+# field unit, the gauss, having dimensions give by:
+#
+#         [gauss] = [2 (c^-2) c statamp / cm] = [statamp / c cm]
+#
+# We then define the gauss using base CGS units to obtain
+#
+#         gauss = statamp / ((cm/s) cm) = statcoulomb / cm^2.
+#
+# Note that this definition happens to give the same result as the definition
+# for the EMU system, so the definitions of the gauss are consistent.
+#
+# This definition gives the same dimensions for the E and B fields and was also
+# known as the "symmetric system".  This system was proposed by Hertz in 1888.
 
-statampere              10 A cm / s c
-statamp                 statampere
-statvolt                dyne cm / statamp sec
-statcoulomb             statamp s
-esu                     statcoulomb
-statcoul                statcoulomb
-statfarad               statamp sec / statvolt
-cmcapacitance           statfarad
-stathenry               statvolt sec / statamp
-statohm                 statvolt / statamp
-statmho                 /statohm
-statmaxwell             statvolt sec
-franklin                statcoulomb
-debye                   1e-18 statcoul cm # unit of electrical dipole moment
-helmholtz               debye/angstrom^2  # Dipole moment per area
-jar                     1000 statfarad    # approx capacitance of Leyden jar
+!var UNITS_SYSTEM gaussian gauss
+!message CGS-Gaussian units selected
+!prompt (Gaussian)
+!endvar
+!var UNITS_SYSTEM gaussian gauss natural-gauss 
++statcoulomb            sqrt(dyne) cm
++A                      10 c_SI statamp
++mu0                    1
++epsilon0               1
++coulombconst           1                  # The gauss is the B field produced
++gauss                  statcoulomb / cm^2 # 1 cm from a wire carrying a current
++weber                  1e8 maxwell        # of 0.5*(c/(cm/s)) stA = 1.5e10 stA
++bohrmagneton           e hbar / 2 electronmass c
++nuclearmagneton        e hbar / 2 protonmass c
+!endvar
+
+# Electromagnetic CGS (Heaviside-Lorentz)
+
+# The Heaviside-Lorentz system is similar to the Gaussian system, but it is
+# "rationalized" so that factors of 4 pi do not appear in Maxwell's equations.
+# The SI system is similarly rationalized, but the other CGS systems are not.
+#
+# The factor of 4 pi appears instead in Coulomb's law, so in this system
+# k_C = 1 / 4 pi, which means the charge unit is defined by
+#
+#                      dyne = (1 / 4 pi) hlu_charge^2 / cm^2.
+# 
+# Since we have the leading constant of (1 / 4pi) the numerical value of the
+# charge number is larger by sqrt(4pi), which in turns means that the HLU
+# charge unit is smaller by this multiple.  But note that the dimensions of the
+# charge unit are the same as the Gaussian system, so both systems measure
+# charge with cm^(3/2) g^(1/2) / s, but the amount of charge for this dimension
+# differs by a factor of sqrt(4pi) between the two systems.
+#
+# Ampere's law for the Heaviside-Lorentz system has the form
+#
+#                B = 1/(2 pi c) * I/r
+
+# The Heaviside-Lorentz system does not appear to have any named units, so we
+# use "hlu" for "Heaviside-Lorentz unit" so we can define values for the basic
+# units in this system.
+
+hlu_charge    statcoulomb / sqrt(4 pi) 
+hlu_current   hlu_charge / sec
+hlu_volt      erg / hlu_charge
+hlu_efield    hlu_volt / cm
+hlu_bfield    sqrt(4 pi) gauss
+
+!var UNITS_SYSTEM hlu
+!message CGS-Heaviside-Lorentz Units selected
+!prompt (HLU)
+!endvar
+!var UNITS_SYSTEM hlu natural planck planck-red
++statcoulomb            sqrt(dyne) cm sqrt(4 pi)
++A                      10 c_SI statamp 
++mu0                    1
++epsilon0               1
+                   # The gauss is the B field produced 1 cm from a wire carrying
+                   # a current of 0.5*(c/(cm/s)) stA, derived from Ampere's law
++gauss                  (1/2 pi c) (0.5 c/(cm/s)) statamp / cm
++weber                  1e8 maxwell
++bohrmagneton           e hbar / 2 electronmass c
++nuclearmagneton        e hbar / 2 protonmass c
+!endvar
+
+# "Natural units" (high energy physics and cosmology)
+#
+# In particle physics "natural units" (which don't seem to have a more specific
+# name) are defined by setting hbar = c = boltzmann = 1.  In this system the
+# electron volt is the only base unit.  The electromagnetic units can be 
+# derived from the rationalized Heaviside-Lorentz units or from Gaussian units.
+# The default form is the rationalized HLU derived version.  
+
+# These are the Heaviside-Lorentz natural units
+
+natural_length          hbar c / eV
+natural_mass            eV / c^2
+natural_time            hbar / eV
+natural_temp            eV / boltzmann
+natural_charge          e / sqrt(4 pi alpha)
+natural_current         natural_charge / natural_time
+natural_force           natural_mass natural_length / natural_time^2
+natural_energy          natural_force natural_length
+natural_power           natural_energy / natural_time
+natural_volt            natural_energy / natural_charge
+natural_Efield          natural_volt / natural_length
+natural_Bfield          natural_volt natural_time / natural_length^2
+
+!var UNITS_SYSTEM natural
+!message Natural units selected (Heaviside-Lorentz based)
+!prompt (natural)
++eV                     !
++h                      2 pi
++c                      1
++boltzmann              1
++m                      e_SI / hbar_SI c_SI eV
++kg                     (c_SI^2 / e_SI) eV
++s                      e_SI / hbar_SI eV
++K                      (k_SI / e_SI) eV
+!endvar
+
+!var UNITS_SYSTEM natural-gauss
+!message Natural units selected (Gaussian based)
+!prompt (natgauss)
++eV                     !
++h                      2 pi
++c                      1
++boltzmann              1
++m                      e_SI / (h_SI / 2 pi) c_SI eV
++kg                     (c_SI^2 / e_SI) eV
++s                      e_SI / (h_SI / 2 pi) eV
++K                      (k_SI / e_SI) eV
+!endvar
+
+#
+# Planck units
+#
+# Planck units are a set of "natural" units based on physical constants c, G,
+# hbar, boltzmann's constant, and epsilon0, often used when working with
+# gravitational theory.  In planck units, all quantities are dimensionless.
+# Some variations are possible for exactly how the units are defined.  We
+# provide two variations, the rationalized planck units and the
+# rationalized-reduced planck units.
+#
+# In both forms the units are defined by c = hbar = boltzmann = 1. 
+# But the choice of rationalized and reduced affects how epsilon0 and G
+# are treated.  
+#
+# In the "rationalized" units, factors of 4 pi do not appear in Maxwell's 
+# equation, and Coulomb's law bears a factor of 1/4 pi.  See the section on
+# the Heaviside-Lorentz units for more about this.  The choice of rationalized 
+# units means that epsilon0 = 1.  (In the unrationalized case, which is not
+# supported, 1/(4 pi epsilon0) = 1.)  
+#
+# The "reduced" units similarly are defined to eliminate factors of 8 pi
+# from the Einstein field equations for gravitation.  With reduced units
+# we set 8 pi G = 1 and with the unreduced units, simply G = 1.
+
+# Rationalized, unreduced planck units
+
+planckmass              sqrt(hbar c / G)
+m_P                     planckmass
+plancktime              hbar / planckmass c^2
+t_P                     plancktime
+plancklength            plancktime c
+l_P                     plancklength
+plancktemperature       hbar / k plancktime
+T_P                     plancktemperature
+planckenergy            planckmass plancklength^2 / plancktime^2
+E_P                     planckenergy
+planckcharge            sqrt(epsilon0 hbar c)
+planckcurrent           planckcharge / plancktime
+planckvolt              planckenergy / planckcharge
+planckEfield            planckvolt / plancklength
+planckBfield            planckvolt plancktime / plancklength^2
+
+# Rationalized, reduced planck units
+
+planckmass_red          sqrt(hbar c / 8 pi G)
+plancktime_red          hbar / planckmass_red c^2
+plancklength_red        plancktime_red c
+plancktemperature_red   hbar / k plancktime_red
+planckenergy_red        planckmass_red plancklength_red^2 / plancktime_red^2
+planckcharge_red        sqrt(epsilon0 hbar c)
+planckcurrent_red       planckcharge_red / plancktime_red
+planckvolt_red          planckenergy_red / planckcharge_red
+planckEfield_red        planckvolt_red / plancklength_red
+planckBfield_red        planckvolt_red plancktime_red / plancklength_red^2
+
+
+!var UNITS_SYSTEM planck
+!message Planck units selected
+!prompt (planck)
++c 1
++h 2 pi
++G 1
++boltzmann 1
++kg sqrt(G_SI / hbar_SI c_SI)
++s  c_SI^2 / hbar_SI kg 
++m  s / c_SI            
++K  k_SI / hbar_SI s    
+!endvar
+
+
+!var UNITS_SYSTEM planck-red
+!message Reduced planck units selected
+!prompt (planck reduced)
++c 1
++h 2 pi
++G 1/8 pi
++boltzmann 1
++kg sqrt(8 pi G_SI / hbar_SI c_SI)
++s  c_SI^2 / hbar_SI kg
++m  s / c_SI           
++K  k_SI / hbar_SI s   
+!endvar
 
 #
 # Some historical electromagnetic units
@@ -1242,7 +1936,7 @@ intohm                  1.000495 ohm  # Defined as the resistance of a
                                       #   long and maintained at 0 degC.
 daniell                 1.042 V       # Meant to be electromotive force of a
                                       #   Daniell cell, but in error by .04 V
-faraday                 N_A electroncharge mol # Charge that must flow to deposit or
+faraday                 N_A e mol     # Charge that must flow to deposit or
 faraday_phys            96521.9 C     #   liberate one gram equivalent of any
 faraday_chem            96495.7 C     #   element.  (The chemical and physical
                                       #   values are off slightly from what is
@@ -1255,66 +1949,31 @@ faraday_chem            96495.7 C     #   element.  (The chemical and physical
 kappline                6000 maxwell  # Named by and for Gisbert Kapp
 siemensunit             0.9534 ohm    # Resistance of a meter long column of
                                       #   mercury with a 1 mm cross section.
-
-!endcategory
-
 #
-# Printed circuit board units.
+# Printed circuit board units.  
 #
-# http://www.ndt-ed.org/GeneralResources/IACS/IACS.htm.
+# http://www.ndt-ed.org/GeneralResources/IACS/IACS.htm.  
 #
 # Conductivity is often expressed as a percentage of IACS.  A copper wire a
-# meter long with a 1 mm^2 cross section has a resistance of 1|58 ohm at
-# 20 deg C.  Copper density is also standarized at that temperature.
+# meter long with a 1 mm^2 cross section has a resistance of 1|58 ohm at 
+# 20 deg C.  Copper density also has a standard IACS value at that temperature.
 #
 
 copperconductivity      58 siemens m / mm^2     # A wire a meter long with
 IACS                    copperconductivity      #   a 1 mm^2 cross section
-copperdensity           8.89 g/cm^3             # The "ounce" measures the
-ouncecopper             oz / ft^2 copperdensity #   thickness of copper used
+copperdensity           8.89 g/cm^3             # The "ounce" measures the     
+ouncecopper             oz / ft^2 copperdensity #   thickness of copper used   
 ozcu                    ouncecopper             #   in circuitboard fabrication
-
-#
-# Radiometric units
-#
-
-!category radiometric "Radiometric Units"
-
-radiant_energy                    J       # Basic unit of radiation
-radiant_energy_density            J/m^3
-radiant_flux                      W
-spectral_flux_frequency           W/Hz
-spectral_flux_wavelength        ? W/m
-radiant_intensity               ? W/sr
-spectral_intensity_frequency    ? W sr^-1 Hz^-1
-spectral_intensity_wavelength   ? W sr^-1 m^-1
-radiance                        ? W sr^-1 m^-2
-spectral_radiance_frequency     ? W sr^-1 m^-2 Hz^-1
-spectral_radiance_wavelength    ? W sr^-1 m^-3
-spectral_irradiance_frequency     W m^-2 Hz^-1
-spectral_irradiance_wavelength  ? W/m^3
-radiosity                         W/m^2
-spectral_radiosity_frequency      W m^-2 Hz^-1
-spectral_radiosity_wavelength     W m^-3
-radiant_exitance                  W/m^2
-spectral_exitance_frequency       W m^-2 Hz^-1
-spectral_exitance_wavelength      W/m^3
-radiant_exposure                  J/m^2
-spectral_exposure_frequency     ? J m^-2 Hz^-1
-spectral_exposure_wavelength      J/m^3
-
-!endcategory
-
+                                                
 #
 # Photometric units
 #
 
-!category photometric "Photometric Units"
-
-luminous_intensity      ? candela
-luminous_flux           ? lumen
-luminous_energy         ? talbot
-illuminance             ? lux
+LUMINOUS_INTENSITY      candela
+LUMINOUS_FLUX           lumen
+LUMINOUS_ENERGY         talbot
+ILLUMINANCE             lux
+EXITANCE                lux
 
 candle                  1.02 candela  # Standard unit for luminous intensity
 hefnerunit              0.9 candle    #   in use before candela
@@ -1350,7 +2009,7 @@ skot                    1e-3 apostilb # measurements relating to dark adapted
                                       # eyes.
 # Luminance measures
 
-luminance               ? nit
+LUMINANCE               nit
 
 nit                     cd/m^2        # Luminance: the intensity per projected
 stilb                   cd / cm^2     # area of an extended luminous source.
@@ -1376,7 +2035,17 @@ footlambert             cd / pi ft^2
 # bril means doubling the luminance.  A luminance of 1 lambert is defined to
 # have a brilliance of 1 bril.
 
-#bril(x) units=[1;lambert]  2^(x+-100) lamberts ;log2(bril/lambert)+100
+bril(x) units=[1;lambert]  2^(x+-100) lamberts ;log2(bril/lambert)+100
+
+# Some luminance data from the IES Lighting Handbook, 8th ed, 1993
+
+sunlum                  1.6e9 cd/m^2  # at zenith
+sunillum                100e3 lux     # clear sky
+sunillum_o              10e3 lux      # overcast sky
+sunlum_h                6e6 cd/m^2    # value at horizon
+skylum                  8000 cd/m^2   # average, clear sky
+skylum_o                2000 cd/m^2   # average, overcast sky
+moonlum                 2500 cd/m^2
 
 #
 # Photographic Exposure Value
@@ -1423,8 +2092,8 @@ iso100                  s100
 
 # Reflected-light meter calibration constant with ISO 100 speed
 
-k1250                   12.5 (cd/m^2) / lx s   # For Canon, Nikon, and Sekonic
-k1400                   14   (cd/m^2) / lx s   # For Kenko (Minolta) and Pentax
+k1250                   12.5 (cd/m2) / lx s   # For Canon, Nikon, and Sekonic
+k1400                   14   (cd/m2) / lx s   # For Kenko (Minolta) and Pentax
 
 # Incident-light meter calibration constant with ISO 100 film
 
@@ -1435,15 +2104,15 @@ c250                    250 lx / lx s         # flat-disc receptor
 # For Kenko (Minolta) or Pentax
 #ev100(x) units=[;cd/m^2] range=(0,) 2^x k1400 / s100; log2(ev100 s100/k1400)
 # For Canon, Nikon, or Sekonic
-#ev100(x) units=[1;cd/m^2] range=(0,) 2^x k1250 / s100; log2(ev100 s100/k1250)
-#EV100()  ev100
+ev100(x) units=[1;cd/m^2] range=(0,) 2^x k1250 / s100; log2(ev100 s100/k1250)
+EV100()  ev100
 
 # Exposure value to scene illuminance with ISO 100 imaging media
 
-#iv100(x) units=[1;lx] range=(0,) 2^x c250 / s100; log2(iv100 s100 / c250)
+iv100(x) units=[1;lx] range=(0,) 2^x c250 / s100; log2(iv100 s100 / c250)
 
 # Other Photographic Exposure Conversions
-#
+# 
 # As part of APEX, ASA PH2.5-1960 proposed several logarithmic quantities
 # related by
 #
@@ -1474,13 +2143,13 @@ c250                    250 lx / lx s         # flat-disc receptor
 
 #N_apex         2^-1.75 lx s    # precise value implied in ASA PH2.12-1961,
                                 # derived from ASA PH2.5-1960.
-#N_apex         0.30 lx s       # rounded value in ASA PH2.5-1960,
+#N_apex         0.30 lx s       # rounded value in ASA PH2.5-1960, 
                                 # ASA PH2.12-1961, and ANSI PH2.7-1986
 #N_apex         0.3162 lx s     # value in ANSI PH2.7-1973
 N_exif          1|3.125 lx s    # value in Exif 2.3 (2010), making Sv(5) = 100
-K_apex1961      11.4 (cd/m^2) / lx s    # value in ASA PH2.12-1961
-K_apex1971      12.5 (cd/m^2) / lx s    # value in ANSI PH3.49-1971; more common
-C_apex1961      224 lx / lx s   # value in PH2.12-1961 (20.83 for I in
+K_apex1961      11.4 (cd/m2) / lx s    # value in ASA PH2.12-1961
+K_apex1971      12.5 (cd/m2) / lx s    # value in ANSI PH3.49-1971; more common
+C_apex1961      224 lx / lx s   # value in PH2.12-1961 (20.83 for I in 
                                 #   footcandles; flat sensor?)
 C_apex1971      322 lx / lx s   # mean value in PH3.49-1971 (30 +/- 5 for I in
                                 # footcandles; hemispherical sensor?)
@@ -1510,7 +2179,7 @@ C_illum         C_apex1961
 # '60 s' will result in Tv of -5.9068906.
 #
 # Exposure Value from f-number and Exposure Time
-#
+# 
 # Because nonlinear unit conversions only accept a single quantity,
 # there is no direct conversion from f-number and exposure time to
 # exposure value EV.  But the EV can be obtained from a combination of
@@ -1529,33 +2198,33 @@ C_illum         C_apex1961
 # to yield the assumed average scene luminance of 3200 cd/m^2.
 
 # convert relative aperture (f-number) to aperture value
-#Av(A)           units=[1;1] domain=[-2,) range=[0.5,)  2^(A/2); 2 log2(Av)
+Av(A)           units=[1;1] domain=[-2,) range=[0.5,)  2^(A/2); 2 log2(Av)
 # convert exposure time to time value
-#Tv(t)           units=[1;s] range=(0,)  2^(-t) s; log2(s / Tv)
+Tv(t)           units=[1;s] range=(0,)  2^(-t) s; log2(s / Tv)
 # convert logarithmic speed Sv in ASA PH2.5-1960 to ASA/ISO arithmetic speed;
 # make arithmetic speed dimensionless
 # 'Sv' conflicts with the symbol for sievert; you can uncomment this function
 # definition if you don't need that symbol
 #Sv(S)    units=[1;1] range=(0,) 2^S / (N_speed/lx s); log2((N_speed/lx s) Sv)
-#Sval(S)   units=[1;1] range=(0,) 2^S / (N_speed/lx s); log2((N_speed/lx s) Sval)
+Sval(S)   units=[1;1] range=(0,) 2^S / (N_speed/lx s); log2((N_speed/lx s) Sval)
 
 # convert luminance value Bv in ASA PH2.12-1961 to luminance
-#Bv(x)           units=[1;cd/m^2] range=(0,) \
-#                2^x K_lum N_speed ; log2(Bv / (K_lum N_speed))
+Bv(x)           units=[1;cd/m^2] range=(0,) \
+                2^x K_lum N_speed ; log2(Bv / (K_lum N_speed))
 
 # convert illuminance value Iv in ASA PH2.12-1961 to illuminance
-#Iv(x)           units=[1;lx] range=(0,) \
-#                2^x C_illum N_speed ; log2(Iv / (C_illum N_speed))
+Iv(x)           units=[1;lx] range=(0,) \
+                2^x C_illum N_speed ; log2(Iv / (C_illum N_speed))
 
-# convert ASA/ISO arithmetic speed Sx to ASA logarithmic speed in
+# convert ASA/ISO arithmetic speed Sx to ASA logarithmic speed in 
 # ASA PH2.5-1960; make arithmetic speed dimensionless
-#Sx(S)           units=[1;1] domain=(0,) \
-#                log2((N_speed/lx s) S); 2^Sx / (N_speed/lx s)
+Sx(S)           units=[1;1] domain=(0,) \
+                log2((N_speed/lx s) S); 2^Sx / (N_speed/lx s)
 
 # convert DIN speed/ISO logarithmic speed in ISO 6:1993 to arithmetic speed
 # for convenience, speed is treated here as if it were dimensionless
-#Sdeg(S)         units=[1;1] range=(0,) 10^((S - 1) / 10) ; (1 + 10 log(Sdeg))
-#Sdin()          Sdeg
+Sdeg(S)         units=[1;1] range=(0,) 10^((S - 1) / 10) ; (1 + 10 log(Sdeg))
+Sdin()          Sdeg
 
 # Numerical Aperture and f-Number of a Lens
 #
@@ -1570,12 +2239,12 @@ C_illum         C_apex1961
 #   NA = 0.5 / f-number
 #
 # convert NA to f-number
-#numericalaperture(x) units=[1;1] domain=(0,1] range=[0.5,) \
-#                     0.5 / x ; 0.5 / numericalaperture
-#NA()            numericalaperture
+numericalaperture(x) units=[1;1] domain=(0,1] range=[0.5,) \
+                     0.5 / x ; 0.5 / numericalaperture
+NA()            numericalaperture
 #
 # convert f-number to itself; restrict values to those possible
-#fnumber(x)      units=[1;1] domain=[0.5,) range=[0.5,) x ; fnumber
+fnumber(x)      units=[1;1] domain=[0.5,) range=[0.5,) x ; fnumber
 
 # Referenced Photographic Standards
 #
@@ -1594,7 +2263,6 @@ C_illum         C_apex1961
 #    pictorial still camera negative film/process systems --
 #    Determination of ISO Speed.
 
-!endcategory
 
 #
 # Astronomical time measurements
@@ -1620,7 +2288,7 @@ C_illum         C_apex1961
 # and a description of how to compute the correction to mean time.
 #
 
-time                    ? second
+TIME                    second
 
 anomalisticyear         365.2596 days       # The time between successive
                                             #   perihelion passages of the
@@ -1662,7 +2330,7 @@ saros                   223 synodicmonth    # The earth, moon and sun appear in
                                             #   is close to 19 eclipse years.)
                                             #   The eclipse will occur about
                                             #   120 degrees west of the
-                                            #   preceeding one because the
+                                            #   preceding one because the
                                             #   saros is not an even number of
                                             #   days.  After 3 saros, an
                                             #   eclipse will occur at
@@ -1732,12 +2400,40 @@ islamicleapyear         355 day          # began counting on July 16, AD 622
                                          # 32.5 years.
 islamicmonth            1|12 islamicyear # They have 29 day and 30 day months.
 
-# The Hewbrew year is also based on lunar months, but synchronized to the solar
+# The Hebrew year is also based on lunar months, but synchronized to the solar
 # calendar.  The months vary irregularly between 29 and 30 days in length, and
 # the years likewise vary.  The regular year is 353, 354, or 355 days long.  To
 # keep up with the solar calendar, a leap month of 30 days is inserted every
 # 3rd, 6th, 8th, 11th, 14th, 17th, and 19th years of a 19 year cycle.  This
 # gives leap years that last 383, 384, or 385 days.
+
+
+# Sidereal days
+
+mercuryday              58.6462 day
+venusday                243.01 day        # retrograde
+earthday                siderealday
+marsday                 1.02595675 day
+jupiterday              0.41354 day
+saturnday               0.4375 day
+uranusday               0.65 day          # retrograde
+neptuneday              0.768 day
+plutoday                6.3867 day
+
+# Sidereal years from http://ssd.jpl.nasa.gov/phys_props_planets.html.  Data
+# was updated in May 2001 based on the 1992 Explanatory Supplement to the
+# Astronomical Almanac and the mean longitude rates.  Apparently the table of
+# years in that reference is incorrect.
+
+mercuryyear             0.2408467 julianyear
+venusyear               0.61519726 julianyear
+earthyear               siderealyear
+marsyear                1.8808476 julianyear
+jupiteryear             11.862615 julianyear
+saturnyear              29.447498 julianyear
+uranusyear              84.016846 julianyear
+neptuneyear             164.79132 julianyear
+plutoyear               247.92065 julianyear
 
 # Objects on the earth are charted relative to a perfect ellipsoid whose
 # dimensions are specified by different organizations.  The ellipsoid is
@@ -1790,30 +2486,321 @@ astronomicalunit         149597870700 m # IAU definition from 2012, exact
 au                     astronomicalunit # ephemeris for the above described
                                         # astronomical unit.  (See the NASA
                                         # site listed above.)
+GMsun        1.32712440018e20 m^3 / s^2 # heliocentric gravitational constant
+solarmass                       GMsun/G # with uncertainty 8e9 is known more
+sunmass                       solarmass # accurately than G. 
 
+
+sundist                 1.0000010178 au # mean earth-sun distance
+moondist                3.844e8 m       # mean earth-moon distance
+sundist_near            1.471e11 m      # earth-sun distance at perihelion
+sundist_far             1.521e11 m      # earth-sun distance at aphelion
+moondist_min		3.564e8 m	# approximate least distance at
+                                        #    perigee 1901-2300
+moondist_max		4.067e8 m	# approximate greatest distance at
+                                        #    apogee 1901-2300
+
+
+# The following are masses for planetary systems, not just the planet itself.
+# The comments give the uncertainty in the denominators.  As noted above,
+# masses are given relative to the solarmass because this is more accurate.
+# The conversion to SI is uncertain because of uncertainty in G, the
+# gravitational constant.
 #
+# Values are from http://ssd.jpl.nasa.gov/astro_constants.html
+
+mercurymass             solarmass / 6023600   # 250
+venusmass               solarmass / 408523.71 # 0.06
+earthmoonmass           solarmass / 328900.56 # 0.02
+marsmass                solarmass / 3098708   # 9
+jupitermass             solarmass / 1047.3486 # 0.0008
+saturnmass              solarmass / 3497.898  # 0.018
+uranusmass              solarmass / 22902.98  # 0.03
+neptunemass             solarmass / 19412.24  # 0.04
+plutomass               solarmass / 1.35e8    # 0.07e8
+
+moonearthmassratio      0.012300034 # uncertainty 3e-9
+earthmass               earthmoonmass / ( 1 + moonearthmassratio)
+moonmass                moonearthmassratio earthmass
+
+# These are the old values for the planetary masses.  They may give
+# the masses of the planets alone.
+
+oldmercurymass             0.33022e24 kg
+oldvenusmass               4.8690e24 kg
+oldmarsmass                0.64191e24 kg
+oldjupitermass             1898.8e24 kg
+oldsaturnmass              568.5e24 kg
+olduranusmass              86.625e24 kg
+oldneptunemass             102.78e24 kg
+oldplutomass               0.015e24 kg
+
+# Mean radius from http://ssd.jpl.nsaa.gov/phys_props_planets.html which in
+# turn cites Global Earth Physics by CF Yoder, 1995.
+
+mercuryradius           2440 km
+venusradius             6051.84 km
+earthradius             6371.01 km
+marsradius              3389.92 km
+jupiterradius           69911 km
+saturnradius            58232 km
+uranusradius            25362 km
+neptuneradius           24624 km
+plutoradius             1151 km
+
+moongravity             1.62 m/s^2
+
+# The Hubble constant gives the speed at which distance galaxies are moving
+# away from the earth according to v = H0*d, where H0 is the hubble constant
+# and d is the distance to the galaxy.
+
+hubble                  70 km/s/Mpc        # approximate
+H0                      hubble
+
+# Parallax is the angular difference between the topocentric (on Earth's
+# surface) and geocentric (at Earth's center) direction toward a celestial body
+# when the body is at a given altitude.  When the body is on the horizon, the
+# parallax is the horizontal parallax; when the body is on the horizon and the
+# observer is on the equator, the parallax is the equatorial horizontal
+# parallax.  When the body is at zenith, the parallax is zero.
+
+lunarparallax  asin(earthradius_equatorial / moondist) # Moon equatorial 
+moonhp         lunarparallax                           # horizontal parallax
+                                                       # at mean distance
+
+# Light from celestial objects is attenuated by passage through Earth's
+# atmosphere.  A body near the horizon passes through much more air than an
+# object at zenith, and is consequently less bright.  Air mass is the ratio of
+# the length of the optical path at a given altitude (angle above the horizon)
+# to the length at zenith.  Air mass at zenith is by definition unity; at the
+# horizon, air mass is approximately 38, though the latter value can vary
+# considerably with atmospheric conditions.  The general formula is # E = E0
+# exp(-c X), where E0 is the value outside Earth's atmosphere, E is the value
+# seen by an observer, X is the air mass and c is the extinction coefficient.
+# A common value for c in reasonably clear air is 0.21, but values can be
+# considerably greater in urban areas.  Apparent altitude is that perceived by
+# an observer; it includes the effect of atmospheric refraction.  There is no
+# shortage of formulas for air mass
+# (https://en.wikipedia.org/wiki/Air_mass_(astronomy)); all are subject to
+# variations in local atmospheric conditions.  The formula used here is simple
+# and is in good agreement with rigorously calculated values under standard
+# conditions.
+#
+# Extraterrestrial illuminance or luminance of an object at a given altitude
+# determined with vmag() or SB_xxx() below can be multiplied by
+# atm_transmission() or atm_transmissionz() to estimate the terrestrial value.
+#
+# Kasten and Young (1989) air mass formula. alt is apparent altitude
+# Reference:
+# Kasten, F., and A.T. Young. 1989. "Revised Optical Air Mass Tables
+#     and Approximation Formula."  Applied Optics.  Vol. 28, 4735–4738.
+#     Bibcode:1989ApOpt..28.4735K. doi:10.1364/AO.28.004735.
+
+airmass(alt) units=[degree;1] domain=[0,90] noerror \
+    1 / (sin(alt) + 0.50572 (alt / degree + 6.07995)^-1.6364)
+
+# zenith is apparent zenith angle (zenith = 90 deg - alt)
+airmassz(zenith) units=[degree;1] domain=[0,90] noerror \
+    1 / (cos(zenith) + 0.50572 (96.07995 - zenith / degree)^-1.6364)
+
+# For reasonably clear air at sea level; values may need adjustment for
+# elevation and local atmospheric conditions
+# for scotopic vision (510 nm), appropriate for the dark-adapted eye
+# extinction_coeff           0.26
+# for photopic vision, appropriate for observing brighter objects such
+# as the full moon
+extinction_coeff	0.21
+
+atm_transmission(alt) units=[degree;1] domain=[0,90] noerror \
+    exp(-extinction_coeff airmass(alt))
+
+# in terms of zenith angle (zenith = 90 deg - alt)
+atm_transmissionz(zenith) units=[degree;1] domain=[0,90] noerror \
+    exp(-extinction_coeff airmassz(zenith))
+
+# Moon and Sun data at mean distances
+moonvmag	-12.74	# Moon apparent visual magnitude at mean distance
+sunvmag		-26.74	# Sun apparent visual magnitude at mean distance
+moonsd	asin(moonradius / moondist) # Moon angular semidiameter at mean distance
+sunsd	asin(sunradius / sundist)   # Sun angular semidiameter at mean distance
+
+# Visual magnitude of star or other celestial object.  The system of stellar
+# magnitudes, developed in ancient Greece, assigned magnitudes from 1
+# (brightest) to 6 (faintest visible to the naked eye).  In 1856, British
+# astronomer Norman Pogson made the system precise, with a magnitude 1 object
+# 100 times as bright as a magnitude 6 object, and each magnitude differing
+# from the next by a constant ratio; the ratio, sometimes known as Pogson's
+# ratio, is thus 100^0.2, or approximately 2.5119.  The logarithm of 100^0.2 is
+# 0.4, hence the common use of powers of 10 and base-10 logarithms.
+#
+# Reference:
+# Allen, C.W. 1976.  Astrophysical Quantities, 3rd ed. 1973, reprinted
+#     with corrections, 1976.  London: Athlone.
+#
+# The function argument is the (dimensionless) visual magnitude; reference
+# illuminance of 2.54e-6 lx is from Allen (2000, 21), and is for outside
+# Earth's atmosphere.  Illuminance values can be adjusted to terrestrial values
+# by multiplying by one of the atm_transmission functions above.
+
+# Illuminance from apparent visual magnitude
+vmag(mag) units=[1;lx] domain=[,]  range=(0,] \
+    2.54e-6 lx 10^(-0.4 mag); -2.5 log(vmag / (2.54e-6 lx))
+
+# Surface brightness of a celestial object of a given visual magnitude
+# is a logarithmic measure of the luminance the object would have if its
+# light were emitted by an object of specified solid angle; it is
+# expressed in magnitudes per solid angle.  Surface brightness can be
+# obtained from the visual magnitude by
+#    S = m + 2.5 log(pi pi k a b),
+# where k is the phase (fraction illuminated), a is the equatorial
+# radius, and b is the polar radius.  For 100% illumination (e.g., full
+# moon), this is often simplified to
+#    S = m + 2.5 log(pi k s^2),
+# where s is the object's angular semidiameter; the units of s determine
+# the units of solid angle.  The visual magnitude and semidiameter must
+# be appropriate for the object's distance; for other than 100%
+# illumination, the visual magnitude must be appropriate for the phase.
+# Luminance values are for outside Earth's atmosphere; they can be
+# adjusted to terrestrial values by multiplying by one of the atm_transmission
+# functions above.
+
+# luminance from surface brightness in magnitudes per square degree
+SB_degree(sb) units=[1;cd/m^2] domain=[,] range=(0,] \
+    vmag(sb) / squaredegree ; \
+    ~vmag(SB_degree squaredegree)
+
+# luminance from surface brightness in magnitudes per square minute
+SB_minute(sb) units=[1;cd/m^2] domain=[,] range=(0,] \
+    vmag(sb) / squareminute ; \
+    ~vmag(SB_minute squareminute)
+
+# luminance from surface brightness in magnitudes per square second
+SB_second(sb) units=[1;cd/m^2] domain=[,] range=(0,] \
+    vmag(sb) / squaresecond ; \
+    ~vmag(SB_second squaresecond)
+
+# luminance from surface brightness in magnitudes per steradian
+SB_sr(sb) units=[1;cd/m^2] domain=[,] range=(0,] \
+    vmag(sb) / sr ; \
+    ~vmag(SB_sr sr)
+
+SB()		SB_second
+SB_sec()	SB_second
+SB_min()	SB_minute
+SB_deg()	SB_degree
+
+# The brightness of one tenth-magnitude star per square degree outside
+# Earth's atmosphere; often used for night sky brightness.
+S10	SB_degree(10)
+
+# Examples for magnitude and surface brightness functions
+# Sun illuminance from visual magnitude
+#     You have: sunvmag
+#     You want:
+# 	    Definition: -26.74 = -26.74
+#     You have: vmag(sunvmag)
+#     You want: lx
+# 	    * 126134.45
+# 	    / 7.9280482e-06
+#
+# Moon surface brightness from visual magnitude and semidiameter at 100%
+# illumination (full moon):
+#     You have: moonvmag
+#     You want:
+# 	    Definition: -12.74 = -12.74
+#     You have: moonsd
+#     You want: arcsec
+# 	    * 932.59484
+# 	    / 0.001072277
+#     You have: moonvmag + 2.5 log(pi 932.59484^2)
+#     You want:
+# 	    Definition: 3.3513397
+#
+# Similar example with specific data obtained from another source (JPL
+# Horizons, https://ssd.jpl.nasa.gov/horizons.cgi); semidiameter is in
+# arcseconds
+#
+#     You have: -12.9 + 2.5 log(pi 2023.201|2^2)
+#     You want:
+# 	    Definition: 3.3679199
+#     You have: SB_second(-12.9 + 2.5 log(pi 2023.201|2^2))
+#     You want:
+# 	    Definition: 4858.6547 cd / m^2
+#
+# If surface brightness is provided by another source (e.g., Horizons),
+# it can simply be used directly:
+# You have: SB_second(3.3679199)
+# You want: cd/m^2
+#         * 4858.6546
+#         / 0.0002058183
+# The illuminance and luminance values are extraterrestrial (outside
+# Earth's atmosphere).  The values at Earth's surface are less than these
+# because of atmospheric extinction.  For example, in the last example
+# above, if the Moon were at an altitude of 55 degrees, the terrestrial
+# luminance could be calculated with
+#     You have: SB_second(3.3679199)
+#     You want: cd/m^2
+# 	    * 4858.6546
+# 	    / 0.0002058183
+#     You have: _ atm_transmission(55 deg)
+#     You want: cd/m^2
+# 	    * 3760.6356
+# 	    / 0.0002659125
+# If desired, photographic exposure can be determined with EV100(),
+# leading to acceptable combinations of aperture and exposure time.
+# For the example above, but with the Moon at 10 degrees,
+#     You have: SB_second(3.3679199) atm_transmission(10 deg)
+#     You want: EV100
+# 	    13.553962
+
+
 # The Hartree system of atomic units, derived from fundamental units
-# of mass (of electron), action (planck's constant), charge, and
-# the coulomb constant.
+# of mass (of electron), action (Planck's constant), charge, and
+# the Coulomb constant.  This system is used in the fields of physical
+# chemistry and condensed matter physics.  
+#
+# The Hartree energy can be derived from m_e, e, hbar, and coulombconst by
+#    hartree = coulombconst^2 m_e e^4 / hbar^2
+# but due to correlations between the measurements for m_e and coulombconst
+# this results in a significant loss of precision.  So we use an alternate 
+# equivalent definition for the hartree and use energy instead of the
+# Coulomb constant to derive the other units.  This method retains the
+# precision.  
 
-!category atomic "Atomic Units"
-
+hartree                 2 rydberg  # Approximate electric potential energy of 
+                                   # the hydrogen atom in its ground state, 
+                                   # and approximately twice its ionization 
+                                   # energy.  
 # Fundamental units
 
 atomicmass              electronmass
-atomiccharge            electroncharge
+atomiccharge            e
 atomicaction            hbar
+atomicenergy            hartree
 
-# derived units (Warning: accuracy is lost from deriving them this way)
+# Derived units
 
-atomiclength            bohrradius
-atomictime              hbar^3/coulombconst^2 atomicmass electroncharge^4 # Period of first
-                                                                          # bohr orbit
-atomicvelocity          atomiclength / atomictime
-atomicenergy            hbar / atomictime
-hartree                 atomicenergy
+atomicvelocity          sqrt(atomicenergy / atomicmass)
+atomictime              atomicaction / atomicenergy
+atomiclength            atomicvelocity atomictime
+atomicforce             atomicenergy / atomiclength
+atomicmomentum          atomicenergy / atomicvelocity
+atomiccurrent           atomiccharge / atomictime
+atomicpotential         atomicenergy / atomiccharge   # electrical potential
+atomicvolt              atomicpotential
+atomicEfield            atomicpotential / atomiclength
+atomicBfield            atomicvolt atomictime / atomiclength^2
+atomictemperature       atomicenergy / boltzmann
 
-!endcategory
+!var UNITS_SYSTEM hartree
+!message Hartree units selected
+!prompt (hartree)
++kg           1/electronmass_SI
++K            k_SI / hbar_SI s 
++m            alpha c_SI electronmass_SI / hbar_SI
++s            alpha c_SI m
++A            1 / s e_SI
+!endvar
 
 #
 # These thermal units treat entropy as charge, from [5]
@@ -1857,97 +2844,51 @@ thermalvolt             K          # thermal potential difference
 # NIST Handbook 44, 2011 ed., Appendix C.
 # Canadian Journal of Physics, 1959, 37:(1) 84, 10.1139/p59-014.
 
-# Survey measures
+US                      1200|3937 m/ft   # These four values will convert
+US-                     US               #   international measures to
+survey-                 US               #   US Survey measures
+geodetic-               US
+int                     3937|1200 ft/m   # Convert US Survey measures to
+int-                    int              #   international measures
 
-!category us_survey "US Survey Measures"
-
-surveyfoot              1200|3937 m
-surveyfeet              surveyfoot
-surveyft                surveyfoot
-surveyinch              1|12 surveyfoot
-surveyinches            surveyinch
-surveyin                surveyinch
-surveyyard              3 surveyfoot
-surveyyd                surveyyard
-surveymile              5280 surveyfoot
-surveymi                surveymile
-
-!endcategory
-
-# International measures
-
-!category int_customary "International Customary Length Measures"
-
-?? International yard and pound, since July 1, 1959.
 inch                    2.54 cm
-inches                  inch
 in                      inch
-?? International yard and pound, since July 1, 1959.
 foot                    12 inch
 feet                    foot
 ft                      foot
-?? International yard and pound, since July 1, 1959.
 yard                    3 ft
 yd                      yard
-?? International yard and pound, since July 1, 1959.
 mile                    5280 ft          # The mile was enlarged from 5000 ft
-mi                      mile             # to this number in order to make
+                                         # to this number in order to make
                                          # it an even number of furlongs.
                                          # (The Roman mile is 5000 romanfeet.)
 line                    1|12 inch  # Also defined as '.1 in' or as '1e-8 Wb'
 rod                     5.5 yard
 perch                   rod
-pole                    rod
-furlong                 40 rod        # From "furrow long"
+furlong                 40 rod           # From "furrow long"
 statutemile             mile
-league                  3 mile
-
-# aliases for international units
-
-intinch                 inch
-intinches               inch
-intin                   in
-intfoot                 foot
-intfeet                 foot
-intft                   foot
-intyard                 yard
-intyd                   yard
-intmile                 mile
-intmi                   mile
-intline                 line
-introd                  rod
-intperch                perch
-intfurlong              furlong
-intleague               league
-
-!endcategory
+league                  3 mile           # Intended to be an an hour's walk
 
 # surveyor's measure
 
-!category us_survey "US Survey Measures"
-
 surveyorschain          66 surveyft
 surveychain             surveyorschain
-gunterschain            surveyorschain
 surveyorspole           1|4 surveyorschain
 surveyorslink           1|100 surveyorschain
-surveyacre              10 surveychain^2
-surveyacrefoot          surveyacre surveyfoot
-
-chain                   66 intfoot
+chain                   66 ft
 link                    1|100 chain
-acre                    10 chain^2       # Acre based on international ft
-acrefoot                acre foot
 ch                      chain
-
-intchain                chain
-intlink                 link
-intacrefoot             acrefoot
-intacre                 acre
+USacre                  10 surveychain^2
+intacre                 10 chain^2       # Acre based on international ft
+intacrefoot             acre foot
+USacrefoot              USacre surveyfoot
+acrefoot                intacrefoot
+acre                    intacre
 section                 mile^2
 township                36 section
 homestead               160 acre # Area of land granted by the 1862 Homestead
                                  # Act of the United States Congress
+gunterschain            surveyorschain
 
 engineerschain          100 ft
 engineerslink           1|100 engineerschain
@@ -1960,7 +2901,6 @@ gurleylink              1|50 gurleychain  # same length
 wingchain               66 feet           # Chain from 1664, introduced by
 winglink                1|80 wingchain    # Vincent Wing, also found in a
                                           # 33 foot length with 40 links.
-
 # early US length standards
 
 # The US has had four standards for the yard: one by Troughton of London
@@ -1979,16 +2919,12 @@ bronzeyard11            914.39980 mm
 mendenhallyard          surveyyard
 internationalyard       yard
 
-!endcategory
+# nautical measure
 
-# international nautical measures
-
-!category int_nautical "International Nautical Units"
-
-intfathom               6 ft     # Originally defined as the distance from
+fathom                  6 ft     # Originally defined as the distance from
                                  #   fingertip to fingertip with arms fully
                                  #   extended.
-intnauticalmile         1852 m   # Supposed to be one minute of latitude at
+nauticalmile            1852 m   # Supposed to be one minute of latitude at
                                  # the equator.  That value is about 1855 m.
                                  # Early estimates of the earth's circumference
                                  # were a bit off.  The value of 1852 m was
@@ -1996,36 +2932,19 @@ intnauticalmile         1852 m   # Supposed to be one minute of latitude at
                                  # The US did not accept this value until
                                  # 1954.  The UK switched in 1970.
 
-fathom                  intfathom
-nauticalmile            intnauticalmile
-intcable                1|10 nauticalmile
-
-cable                   intcable              # international cable
+cable                   1|10 nauticalmile
+intcable                cable              # international cable
 cablelength             cable
-
-!endcategory
-
-# survey nautical measures
-
-!category us_nautical "US Survey Nautical Units"
-
-surveynauticalmile      6080.20 surveyfoot # Before 1954
-surveyfathom            6 surveyfoot
-surveycable             100 surveyfathom
-navycablelength         720 surveyft           # used for depth in water
+UScable                 100 USfathom
+navycablelength         720 USft           # used for depth in water
 marineleague            3 nauticalmile
 geographicalmile        brnauticalmile
 knot                    nauticalmile / hr
 click                   km       # US military slang
 klick                   click
 
-!endcategory
-
 # Avoirdupois weight
 
-!category avoirdupois "Avoirdupois Weights"
-
-?? International yard and pound, since July 1, 1959. Avoirdupois.
 pound                   0.45359237 kg   # The one normally used
 lb                      pound           # From the latin libra
 grain                   1|7000 pound    # The grain is the same in all three
@@ -2046,12 +2965,8 @@ quarterweight           1|4 uston
 shortquarterweight      1|4 shortton
 shortquarter            shortquarterweight
 
-!endcategory
-
 # Troy Weight.  In 1828 the troy pound was made the first United States
 # standard weight.  It was to be used to regulate coinage.
-
-!category troy "Troy Weights"
 
 troypound               5760 grain
 troyounce               1|12 troypound
@@ -2065,11 +2980,7 @@ usassayton              mg uston / troyounce
 brassayton              mg brton / troyounce
 fineounce               troyounce       # A troy ounce of 99.5% pure gold
 
-!endcategory
-
 # Some other jewelers units
-
-!category jewelers "Jewelers' Units"
 
 metriccarat             0.2 gram        # Defined in 1907
 metricgrain             50 mg
@@ -2082,23 +2993,14 @@ momme                   3.75 grams      # Traditional Japanese unit based
                                         # pearls in modern times and also for
                                         # silk density.  The definition here
                                         # was adopted in 1891.
-
-!endcategory
-
 # Apothecaries' weight
-
-!category apothecary "Apothecaries' Weights"
 
 appound                 troypound
 apounce                 troyounce
 apdram                  1|8 apounce
 apscruple               1|3 apdram
 
-!endcategory
-
 # Liquid measure
-
-!category us_volume "US Volume Measures"
 
 usgallon                231 in^3        # US liquid measure is derived from
 gal                     gallon          # the British wine gallon of 1707.
@@ -2165,13 +3067,9 @@ heapedbushel            1.278 usbushel# The following explanation for this
                                       #   that value if the heap is taken to
                                       #   have an 18.5 inch diameter.
 
-!endcategory
-
 # Grain measures.  The bushel as it is used by farmers in the USA is actually
 # a measure of mass which varies for different commodities.  Canada uses the
 # same bushel masses for most commodities, but not for oats.
-
-!category us_grain "US Grain Measures"
 
 wheatbushel             60 lb
 soybeanbushel           60 lb
@@ -2182,11 +3080,7 @@ oatbushel               32 lb
 ricebushel              45 lb
 canada_oatbushel        34 lb
 
-!endcategory
-
 # Wine and Spirits measure
-
-!category wine "Wine and Spirits Measures"
 
 ponyvolume              1 usfloz
 jigger                  1.5 usfloz   # Can vary between 1 and 2 usfloz
@@ -2195,57 +3089,85 @@ eushot                  25 ml      # EU standard spirits measure
 fifth                   1|5 usgallon
 winebottle              750 ml     # US industry standard, 1979
 winesplit               1|4 winebottle
-wineglass               4 usfloz
 magnum                  1.5 liter  # Standardized in 1979, but given
                                    # as 2 qt in some references
 metrictenth             375 ml
 metricfifth             750 ml
 metricquart             1 liter
 
-!endcategory
-
 # Old British bottle size
-
-!category br_bottles "British Bottle Sizes"
 
 reputedquart            1|6 brgallon
 reputedpint             1|2 reputedquart
 brwinebottle            reputedquart       # Very close to 1|5 winegallon
 
-!endcategory
-
 # French champagne bottle sizes
-
-!category fr_bottle "French CHampagne Bottle Sizes"
 
 split                   200 ml
 jeroboam                2 magnum
 rehoboam                3 magnum
 methuselah              4 magnum
+imperialbottle          4 magnum
 salmanazar              6 magnum
 balthazar               8 magnum
 nebuchadnezzar          10 magnum
+solomon                 12 magnum
+melchior                12 magnum
+sovereign               17.5 magnum
+primat                  18 magnum
+goliath                 18 magnum
+melchizedek             20 magnum
+midas                   20 magnum
 
-!endcategory
+# The wine glass doesn't seem to have an official standard, but the same value
+# is suggested by several organization. 
+
+# https://www.rethinkingdrinking.niaaa.nih.gov/
+# http://www.rethinkyourdrinking.ca/what-is-a-standard-drink/
+# https://www.drinkaware.co.uk/
+# https://www.gov.uk/government/uploads/system/uploads/attachment_data/file/545937/UK_CMOs__report.pdf
+# http://www.alcohol.gov.au/internet/alcohol/publishing.nsf/content/drinksguide-cnt
+
+wineglass               150 mL     # the size of a "typical" serving
+
+# A unit of alcohol is a specified mass of pure ethyl alcohol.
+# The term is used officially in the UK, but other countries use the same
+# concept but with different values.  For example, the UK value of 8 g is
+# nominally the amount of alcohol that a typical adult can metabolize in
+# one hour.  Values for several countries, converted to a volumetric basis:
+
+alcoholunitus           14 g   / ethanoldensity
+alcoholunitca           13.6 g / ethanoldensity
+alcoholunituk            8 g   / ethanoldensity
+alcoholunitau           10 g   / ethanoldensity
+
+# Example: for 12% ABV (alcohol by volume)
+# alcoholunitus / 12% = 147.8 mL, close to the “standard” serving of 150 mL.
+
+
+# Coffee 
+#
+# The recommended ratio of coffee to water. Values vary considerably;
+# one is from the  Specialty Coffee Association of America
+# http://scaa.org/?page=resources&d=brewing-best-practices
+
+coffeeratio             55 g/L  # ± 10%
+
+# other recommendations are more loose, e.g.,
+# http://www.ncausa.org/About-Coffee/How-to-Brew-Coffee
+
 
 #
 # Water is "hard" if it contains various minerals, expecially calcium
 # carbonate.
 #
 
-!category water_hardness "Water Hardness Measures"
-
 clarkdegree     grains/brgallon # Content by weigh of calcium carbonate
 gpg             grains/usgallon # Divide by water's density to convert to
                                 #   a dimensionless concentration measure
-
-!endcategory
-
 #
 # Shoe measures
 #
-
-!category shoes "Shoe Measures"
 
 shoeiron                1|48 inch    # Used to measure leather in soles
 shoeounce               1|64 inch    # Used to measure non-sole shoe leather
@@ -2264,14 +3186,14 @@ shoe_women0             (7+11|12) inch
 shoe_boys0              (3+11|12) inch
 shoe_girls0             (3+7|12) inch
 
-#shoesize_men(n) units=[1;inch]   shoe_men0 + n shoesize_delta ; \
-#                                (shoesize_men+(-shoe_men0))/shoesize_delta
-#shoesize_women(n) units=[1;inch] shoe_women0 + n shoesize_delta ; \
-#                                (shoesize_women+(-shoe_women0))/shoesize_delta
-#shoesize_boys(n) units=[1;inch]  shoe_boys0 + n shoesize_delta ; \
-#                                (shoesize_boys+(-shoe_boys0))/shoesize_delta
-#shoesize_girls(n) units=[1;inch] shoe_girls0 + n shoesize_delta ; \
-#                                (shoesize_girls+(-shoe_girls0))/shoesize_delta
+shoesize_men(n) units=[1;inch]   shoe_men0 + n shoesize_delta ; \
+                                (shoesize_men+(-shoe_men0))/shoesize_delta
+shoesize_women(n) units=[1;inch] shoe_women0 + n shoesize_delta ; \
+                                (shoesize_women+(-shoe_women0))/shoesize_delta
+shoesize_boys(n) units=[1;inch]  shoe_boys0 + n shoesize_delta ; \
+                                (shoesize_boys+(-shoe_boys0))/shoesize_delta
+shoesize_girls(n) units=[1;inch] shoe_girls0 + n shoesize_delta ; \
+                                (shoesize_girls+(-shoe_girls0))/shoesize_delta
 
 # European shoe size.  According to
 #      http://www.shoeline.com/footnotes/shoeterm.shtml
@@ -2280,12 +3202,15 @@ shoe_girls0             (3+7|12) inch
 
 europeshoesize          2|3 cm
 
-!endcategory
-
 #
 # USA slang units
 #
 
+buck                    US$
+fin                     5 US$
+sawbuck                 10 US$
+usgrand                 1000 US$
+greenback               US$
 key                     kg           # usually of marijuana, 60's
 lid                     1 oz         # Another 60's weed unit
 footballfield           usfootballfield
@@ -2307,77 +3232,40 @@ marathon                26 miles + 385 yards
 # meter.  This happened after an international agreement in 1959 to align the
 # world's measurement systems.
 
-# In 1922, Seers, Jolly and
-#   Johnson found the yard to be
-#   0.91439841 meters.
-#   Used starting in the 1930's.
+UK                      UKlength_SJJ
+UK-                     UK
+british-                UK
 
-!category br_length "British Length Measures"
-
-UKSJJyard               0.91439841 meter
-UKSJJfoot               1|3 UKSJJyard
-UKSJJinch               1|12 UKSJJfoot
-UKSJJmile               5280 UKSJJfoot
-
-bryard                  UKSJJyard
-brfoot                  UKSJJfoot
-brinch                  UKSJJinch
-brmile                  UKSJJmile
-
-UKyard                  UKSJJyard
-UKfoot                  UKSJJfoot
-UKinch                  UKSJJinch
-UKmile                  UKSJJmile
-UKft                    UKfoot
-
-# Benoit found the yard to be
-#   0.9143992 m at a weights and
-#   measures conference around
-#   1896.   Legally sanctioned
-#   in 1898.
-UKByard                 0.9143992 meter
-UKBfoot                 1|3 UKByard
-UKBinch                 1|12 UKBfoot
-UKBmile                 5280 UKBfoot
-
-# In 1866 Clarke found the meter
-#   to be 1.09362311 yards.  This
-#   conversion was legalized
-#   around 1878.
-UKCyard                 1|1.09362311 meter
-UKCfoot                 1|3 UKCyard
-UKCinch                 1|12 UKCfoot
-UKCmile                 5280 UKCfoot
-
-# In 1816 Kater found this ratio
-#   for the meter and inch.  This
-#   value was used as the legal
-#   conversion ratio when the
-#   metric system was legalized
-#   for contract in 1864.
-UKKinch                 1|39.37079 meter
-UKKfoot                 12 UKKinch
-UKKyard                 3 UKKfoot
-UKKmile                 5280 UKKfoot
-
+UKlength_B            0.9143992 meter / yard  # Benoit found the yard to be
+                                              #   0.9143992 m at a weights and
+                                              #   measures conference around
+                                              #   1896.   Legally sanctioned
+                                              #   in 1898.
+UKlength_SJJ          0.91439841 meter / yard # In 1922, Seers, Jolly and
+                                              #   Johnson found the yard to be
+                                              #   0.91439841 meters.
+                                              #   Used starting in the 1930's.
+UKlength_K              meter / 39.37079 inch # In 1816 Kater found this ratio
+                                              #   for the meter and inch.  This
+                                              #   value was used as the legal
+                                              #   conversion ratio when the
+                                              #   metric system was legalized
+                                              #   for contract in 1864.
+UKlength_C            meter / 1.09362311 yard # In 1866 Clarke found the meter
+                                              #   to be 1.09362311 yards.  This
+                                              #   conversion was legalized
+                                              #   around 1878.
 brnauticalmile          6080 ft               # Used until 1970 when the UK
 brknot                  brnauticalmile / hr   #   switched to the international
 brcable                 1|10 brnauticalmile   #   nautical mile.
-brstatutemile           5280 brfoot
-english_land_league     3 brmile
-brleague                english_land_league
 admiraltymile           brnauticalmile
 admiraltyknot           brknot
 admiraltycable          brcable
 seamile                 6000 ft
 shackle                 15 fathoms            # Adopted 1949 by British navy
 
-!endcategory
-
 # British Imperial weight is mostly the same as US weight.  A few extra
 # units are added here.
-
-!category br_weight "British Weight Measures"
 
 clove                   7 lb
 stone                   14 lb
@@ -2388,11 +3276,7 @@ longhundredweight       brhundredweight
 longton                 20 brhundredweight
 brton                   longton
 
-!endcategory
-
 # British Imperial volume measures
-
-!category br_volume "British Volume Measures"
 
 brminim                 1|60 brdram
 brscruple               1|3 brdram
@@ -2496,11 +3380,7 @@ imperialbeerhogshead    brbeerhogshead
 imperialbeerbutt        brbeerbutt
 imperialfirkin          brfirkin
 
-!endcategory
-
 # obscure British lengths
-
-!category br_length "British Length Measures"
 
 barleycorn              1|3 UKinch   # Given in Realm of Measure as the
                                      # difference between successive shoe sizes
@@ -2509,7 +3389,7 @@ nail                    1|16 UKyard  # Originally the width of the thumbnail,
                                      #   meaning of 1|16 and settled on the
                                      #   nail of a yard or 1|16 yards as its
                                      #   final value.  [12]
-brpole                  16.5 UKft    # This was 15 Saxon feet, the Saxon
+pole                    16.5 UKft    # This was 15 Saxon feet, the Saxon
 rope                    20 UKft      #   foot (aka northern foot) being longer
 englishell              45 UKinch
 flemishell              27 UKinch
@@ -2519,8 +3399,6 @@ span                    9 UKinch     # supposed to be distance from thumb
                                      #   to pinky with full hand extension
 goad                    4.5 UKft     # used for cloth, possibly named after the
                                      #   stick used for prodding animals.
-
-!endcategory
 
 # misc obscure British units
 
@@ -2542,24 +3420,15 @@ basebox                 31360 in^2      # Used in metal plating
 
 # alternate spellings
 
-metre                   meter
 gramme                  gram
 litre                   liter
 dioptre                 diopter
 aluminium               aluminum
 sulphur                 sulfur
-androstenolone          dehydroepiandrosterone
-androstanolone          dihydrotestosterone
-oestrone                estrone
-oestradiol              estradiol
-oestriol                estriol
-oestetrol               estetrol
 
 #
 # Units derived the human body (may not be very accurate)
 #
-
-!category human_measures "Human Body Measurements"
 
 geometricpace           5 ft   # distance between points where the same
                                # foot hits the ground
@@ -2580,21 +3449,18 @@ shaftment               6 inch # Distance from tip of outstretched thumb to the
 smoot              5 ft + 7 in # Created as part of an MIT fraternity prank.
                                #   In 1958 Oliver Smoot was used to measure
                                #   the length of the Harvard Bridge, which was
-                               #   marked off in smooth lengths.  These
+                               #   marked off in Smoot lengths.  These
                                #   markings have been maintained on the bridge
                                #   since then and repainted by subsequent
                                #   incoming fraternity members.  During a
-                               #   bridge rennovation the new sidewalk was
-                               #   scored every smooth rather than at the
+                               #   bridge renovation the new sidewalk was
+                               #   scored every Smoot rather than at the
                                #   customary 6 ft spacing.
-
-!endcategory
+tomcruise       5 ft + 7.75 in # Height of Tom Cruise
 
 #
 # Cooking measures
 #
-
-!category us_volume "US Volume Measures"
 
 # Common abbreviations
 
@@ -2628,10 +3494,10 @@ legaltablespoon         1|16 legalcup
 legaltbsp               legaltablespoon
 
 # Scoop size.  Ice cream scoops in the US are marked with numbers
-# indicating the number of scoops requird to fill a US quart.
+# indicating the number of scoops required to fill a US quart.
 
-#scoop(n)  units=[1;cup] domain=[4,100] range=[0.04,1] \
-#           32 usfloz / n ; 32 usfloz / scoop
+scoop(n)  units=[1;cup] domain=[4,100] range=[0.04,1] \
+           32 usfloz / n ; 32 usfloz / scoop
 
 
 # US can sizes.
@@ -2643,11 +3509,7 @@ number3can              4 uscups
 number5can              7 uscups
 number10can             105 usfloz
 
-!endcategory
-
 # British measures
-
-!category br_volume "British Volume Measures"
 
 brcup                   1|2 brpint
 brteacup                1|3 brpint
@@ -2661,11 +3523,7 @@ brtbl                   brtablespoon
 brtbsp                  brtablespoon
 brtblsp                 brtablespoon
 
-!endcategory
-
 # Australian
-
-!category au_volume "Australian Volume Measures"
 
 australiatablespoon     20 ml
 austbl                  australiatablespoon
@@ -2673,8 +3531,6 @@ austbsp                 australiatablespoon
 austblsp                australiatablespoon
 australiateaspoon       1|4 australiatablespoon
 austsp                  australiateaspoon
-
-!endcategory
 
 # Italian
 
@@ -2704,6 +3560,64 @@ ollock                  1|4 liter      # Is this right?
 # Japanese
 
 japancup                200 ml
+
+# densities of cooking ingredients from The Cake Bible by Rose Levy Beranbaum
+# so you can convert '2 cups sugar' to grams, for example, or in the other
+# direction grams could be converted to 'cup flour_scooped'.
+
+butter                  8 oz/uscup
+butter_clarified        6.8 oz/uscup
+cocoa_butter            9 oz/uscup
+shortening              6.75 oz/uscup   # vegetable shortening
+oil                     7.5 oz/uscup
+cakeflour_sifted        3.5 oz/uscup    # The density of flour depends on the
+cakeflour_spooned       4 oz/uscup      # measuring method.  "Scooped",  or
+cakeflour_scooped       4.5 oz/uscup    # "dip and sweep" refers to dipping a
+flour_sifted            4 oz/uscup      # measure into a bin, and then sweeping
+flour_spooned           4.25 oz/uscup   # the excess off the top.  "Spooned"
+flour_scooped           5 oz/uscup      # means to lightly spoon into a measure
+breadflour_sifted       4.25 oz/uscup   # and then sweep the top.  Sifted means
+breadflour_spooned      4.5 oz/uscup    # sifting the flour directly into a
+breadflour_scooped      5.5 oz/uscup    # measure and then sweeping the top.
+cornstarch              120 grams/uscup
+dutchcocoa_sifted       75 g/uscup      # These are for Dutch processed cocoa
+dutchcocoa_spooned      92 g/uscup
+dutchcocoa_scooped      95 g/uscup
+cocoa_sifted            75 g/uscup      # These are for nonalkalized cocoa
+cocoa_spooned           82 g/uscup
+cocoa_scooped           95 g/uscup
+heavycream              232 g/uscup
+milk                    242 g/uscup
+sourcream               242 g/uscup
+molasses                11.25 oz/uscup
+cornsyrup               11.5 oz/uscup
+honey                   11.75 oz/uscup
+sugar                   200 g/uscup
+powdered_sugar          4 oz/uscup
+brownsugar_light        217 g/uscup     # packed
+brownsugar_dark         239 g/uscup
+
+baking_powder           4.6 grams / ustsp
+salt                    6 g / ustsp
+koshersalt              2.8 g / ustsp   # Diamond Crystal kosher salt
+koshersalt_morton       4.8 g / ustsp   # Morton kosher salt
+                                        # Values are from the nutrition info
+                                        # on the packages
+
+
+# Egg weights and volumes for a USA large egg
+
+egg                     50 grams        # without shell
+eggwhite                30 grams
+eggyolk                 18.6 grams
+eggvolume               3 ustablespoons + 1|2 ustsp
+eggwhitevolume          2 ustablespoons
+eggyolkvolume           3.5 ustsp
+
+# Alcohol density
+
+ethanoldensity          0.7893 g/cm^3   # From CRC Handbook, 91st Edition
+alcoholdensity          ethanoldensity
 
 #
 # Density measures.  Density has traditionally been measured on a variety of
@@ -2736,7 +3650,7 @@ japancup                200 ml
 #
 # But I'm using equation (3) which is credited to Starzak and Peacock,
 # "Water activity coefficient in aqueous solutions of sucrose--A comprehensive
-# data analyzis.  Zuckerindustrie, 122, 380-387.  (I couldn't find this
+# data analysis.  Zuckerindustrie, 122, 380-387.  (I couldn't find this
 # document.)
 #
 # Note that the range of validity is uncertain, but answers are in agreement
@@ -2761,8 +3675,8 @@ japancup                200 ml
 # sc(x)  (x / 342.3) / (( x/342.3) + (100-x)/18.02); \
 #        100 sc 342.3|18.02 / (sc (342.3|18.02-1)+1)
 #
-# Here is a simplfied version of this equation where the temperature of boiling
-# water has been fixed at 100 degrees Celcius and the argument is now the
+# Here is a simplified version of this equation where the temperature of boiling
+# water has been fixed at 100 degrees Celsius and the argument is now the
 # concentration (brix).
 #
 # sugar_bpe(x) ((1+ 0.48851085 * sc(x)^2 (1+ -1.0038 sc(x) + -0.24653 sc(x)^2)) \
@@ -2775,25 +3689,25 @@ japancup                200 ml
 # This table gives the boiling point elevation as a function of the sugar syrup
 # concentration expressed as a percentage.
 
-#sugar_conc_bpe[K] \
-# 0 0.0000   5 0.0788  10 0.1690  15 0.2729  20 0.3936  25 0.5351  \
-#30 0.7027  35 0.9036  40 1.1475  42 1.2599  44 1.3825  46 1.5165  \
-#48 1.6634  50 1.8249  52 2.0031  54 2.2005  56 2.4200  58 2.6651  \
-#60 2.9400  61 3.0902  62 3.2499  63 3.4198  64 3.6010  65 3.7944  \
-#66 4.0012  67 4.2227  68 4.4603  69 4.7156  70 4.9905  71 5.2870  \
-#72 5.6075  73 5.9546  74 6.3316  75 6.7417  76 7.1892  77 7.6786  \
-#78.0  8.2155  79.0  8.8061  80.0  9.4578  80.5  9.8092  81.0 10.1793  \
-#81.5 10.5693  82.0 10.9807  82.5 11.4152  83.0 11.8743  83.5 12.3601  \
-#84.0 12.8744  84.5 13.4197  85.0 13.9982  85.5 14.6128  86.0 15.2663  \
-#86.5 15.9620  87.0 16.7033  87.5 17.4943  88.0 18.3391  88.5 19.2424  \
-#89.0 20.2092  89.5 21.2452  90.0 22.3564  90.5 23.5493  91.0 24.8309  \
-#91.5 26.2086  92.0 27.6903  92.5 29.2839  93.0 30.9972  93.5 32.8374  \
-#94.0 34.8104  94.5 36.9195  95.0 39.1636  95.5 41.5348  96.0 44.0142  \
-#96.5 46.5668  97.0 49.1350  97.5 51.6347  98.0 53.9681  98.1 54.4091  \
-#98.2 54.8423  98.3 55.2692  98.4 55.6928  98.5 56.1174  98.6 56.5497  \
-#98.7 56.9999  98.8 57.4828  98.9 58.0206  99.0 58.6455  99.1 59.4062  \
-#99.2 60.3763  99.3 61.6706  99.4 63.4751  99.5 66.1062  99.6 70.1448  \
-#99.7 76.7867
+sugar_conc_bpe[K] \
+ 0 0.0000   5 0.0788  10 0.1690  15 0.2729  20 0.3936  25 0.5351  \
+30 0.7027  35 0.9036  40 1.1475  42 1.2599  44 1.3825  46 1.5165  \
+48 1.6634  50 1.8249  52 2.0031  54 2.2005  56 2.4200  58 2.6651  \
+60 2.9400  61 3.0902  62 3.2499  63 3.4198  64 3.6010  65 3.7944  \
+66 4.0012  67 4.2227  68 4.4603  69 4.7156  70 4.9905  71 5.2870  \
+72 5.6075  73 5.9546  74 6.3316  75 6.7417  76 7.1892  77 7.6786  \
+78.0  8.2155  79.0  8.8061  80.0  9.4578  80.5  9.8092  81.0 10.1793  \
+81.5 10.5693  82.0 10.9807  82.5 11.4152  83.0 11.8743  83.5 12.3601  \
+84.0 12.8744  84.5 13.4197  85.0 13.9982  85.5 14.6128  86.0 15.2663  \
+86.5 15.9620  87.0 16.7033  87.5 17.4943  88.0 18.3391  88.5 19.2424  \
+89.0 20.2092  89.5 21.2452  90.0 22.3564  90.5 23.5493  91.0 24.8309  \
+91.5 26.2086  92.0 27.6903  92.5 29.2839  93.0 30.9972  93.5 32.8374  \
+94.0 34.8104  94.5 36.9195  95.0 39.1636  95.5 41.5348  96.0 44.0142  \
+96.5 46.5668  97.0 49.1350  97.5 51.6347  98.0 53.9681  98.1 54.4091  \
+98.2 54.8423  98.3 55.2692  98.4 55.6928  98.5 56.1174  98.6 56.5497  \
+98.7 56.9999  98.8 57.4828  98.9 58.0206  99.0 58.6455  99.1 59.4062  \
+99.2 60.3763  99.3 61.6706  99.4 63.4751  99.5 66.1062  99.6 70.1448  \
+99.7 76.7867
 
 # Using the brix table we can use this to produce a mapping from boiling point
 # to density which makes all of the units interconvertible.  Because the brix
@@ -2802,31 +3716,31 @@ japancup                200 ml
 # making.  The "hard crack" stage continues up to 310 F.
 
 # Boiling point elevation
-#sugar_bpe(T) units=[K;g/cm^3] domain=[0,39.1636] range=[0.99717,1.5144619] \
-#               brix(~sugar_conc_bpe(T)); sugar_conc_bpe(~brix(sugar_bpe))
+sugar_bpe(T) units=[K;g/cm^3] domain=[0,39.1636] range=[0.99717,1.5144619] \
+               brix(~sugar_conc_bpe(T)); sugar_conc_bpe(~brix(sugar_bpe))
 # Absolute boiling point (produces an absolute temperature)
-#sugar_bp(T) units=[K;g/cm^3] domain=[373.15,412.3136] \
-#                                         range=[0.99717,1.5144619] \
-#                        brix(~sugar_conc_bpe(T-tempC(100))) ;\
-#                        sugar_conc_bpe(~brix(sugar_bp))+tempC(100)
+sugar_bp(T) units=[K;g/cm^3] domain=[373.15,412.3136] \
+                                         range=[0.99717,1.5144619] \
+                        brix(~sugar_conc_bpe(T-tempC(100))) ;\
+                        sugar_conc_bpe(~brix(sugar_bp))+tempC(100)
 
 # In practice dealing with the absolute temperature is annoying because it is
 # not possible to convert to a nested function, so you're stuck retyping the
 # absolute temperature in Kelvins to convert to celsius or Fahrenheit.  To
 # prevent this we supply definitions that build in the temperature conversion
-# and produce results in the Fahrenheit and Celcius scales.  So using these
+# and produce results in the Fahrenheit and Celsius scales.  So using these
 # measures, to convert 46 degrees Baume to a Fahrenheit boiling point:
 #
 #      You have: baume(45)
 #      You want: sugar_bpF
 #              239.05647
 #
-#sugar_bpF(T) units=[1;g/cm^3] domain=[212,282.49448] range=[0.99717,1.5144619]\
-#                        brix(~sugar_conc_bpe(tempF(T)+-tempC(100))) ;\
-#                        ~tempF(sugar_conc_bpe(~brix(sugar_bpF))+tempC(100))
-#sugar_bpC(T) units=[1;g/cm^3] domain=[100,139.1636] range=[0.99717,1.5144619]\
-#                        brix(~sugar_conc_bpe(tempC(T)+-tempC(100))) ;\
-#                        ~tempC(sugar_conc_bpe(~brix(sugar_bpC))+tempC(100))
+sugar_bpF(T) units=[1;g/cm^3] domain=[212,282.49448] range=[0.99717,1.5144619]\
+                        brix(~sugar_conc_bpe(tempF(T)+-tempC(100))) ;\
+                        ~tempF(sugar_conc_bpe(~brix(sugar_bpF))+tempC(100))
+sugar_bpC(T) units=[1;g/cm^3] domain=[100,139.1636] range=[0.99717,1.5144619]\
+                        brix(~sugar_conc_bpe(tempC(T)+-tempC(100))) ;\
+                        ~tempC(sugar_conc_bpe(~brix(sugar_bpC))+tempC(100))
 
 # Degrees Baume is used in European recipes to specify the density of a sugar
 # syrup.  An entirely different definition is used for densities below
@@ -2835,20 +3749,20 @@ japancup                200 ml
 # Holland had a value of 144, and the new scale or Gerlach scale used 146.78.
 
 baumeconst 145      # US value
-#baume(d) units=[1;g/cm^3] domain=[0,145) range=[1,) \
-#                          (baumeconst/(baumeconst+-d)) g/cm^3 ; \
-#                          (baume+((-g)/cm^3)) baumeconst / baume
+baume(d) units=[1;g/cm^3] domain=[0,145) range=[1,) \
+                          (baumeconst/(baumeconst+-d)) g/cm^3 ; \
+                          (baume+((-g)/cm^3)) baumeconst / baume
 
 # It's not clear if this value was ever used with negative degrees.
-#twaddell(x) units=[1;g/cm^3] domain=[-200,) range=[0,) \
-#                             (1 + 0.005 x) g / cm^3 ; \
-#                             200 (twaddell / (g/cm^3) +- 1)
+twaddell(x) units=[1;g/cm^3] domain=[-200,) range=[0,) \
+                             (1 + 0.005 x) g / cm^3 ; \
+                             200 (twaddell / (g/cm^3) +- 1)
 
 # The degree quevenne is a unit for measuring the density of milk.
 # Similarly it's unclear if negative values were allowed here.
-#quevenne(x) units=[1;g/cm^3] domain=[-1000,) range=[0,) \
-#                             (1 + 0.001 x) g / cm^3 ; \
-#                             1000 (quevenne / (g/cm^3) +- 1)
+quevenne(x) units=[1;g/cm^3] domain=[-1000,) range=[0,) \
+                             (1 + 0.001 x) g / cm^3 ; \
+                             1000 (quevenne / (g/cm^3) +- 1)
 
 # Degrees brix measures sugar concentration by weigh as a percentage, so a
 # solution that is 3 degrees brix is 3% sugar by weight.  This unit was named
@@ -2861,38 +3775,554 @@ baumeconst 145      # US value
 # word "apparent" to refer to measurements being made in air with brass
 # weights rather than vacuum.
 
-#brix[0.99717g/cm^3]\
-#    0 1.00000  1 1.00390  2 1.00780  3 1.01173  4 1.01569  5 1.01968 \
-#    6 1.02369  7 1.02773  8 1.03180  9 1.03590 10 1.04003 11 1.04418 \
-#   12 1.04837 13 1.05259 14 1.05683 15 1.06111 16 1.06542 17 1.06976 \
-#   18 1.07413 19 1.07853 20 1.08297 21 1.08744 22 1.09194 23 1.09647 \
-#   24 1.10104 25 1.10564 26 1.11027 27 1.11493 28 1.11963 29 1.12436 \
-#   30 1.12913 31 1.13394 32 1.13877 33 1.14364 34 1.14855 35 1.15350 \
-#   36 1.15847 37 1.16349 38 1.16853 39 1.17362 40 1.17874 41 1.18390 \
-#   42 1.18910 43 1.19434 44 1.19961 45 1.20491 46 1.21026 47 1.21564 \
-#   48 1.22106 49 1.22652 50 1.23202 51 1.23756 52 1.24313 53 1.24874 \
-#   54 1.25439 55 1.26007 56 1.26580 57 1.27156 58 1.27736 59 1.28320 \
-#   60 1.28909 61 1.29498 62 1.30093 63 1.30694 64 1.31297 65 1.31905 \
-#   66 1.32516 67 1.33129 68 1.33748 69 1.34371 70 1.34997 71 1.35627 \
-#   72 1.36261 73 1.36900 74 1.37541 75 1.38187 76 1.38835 77 1.39489 \
-#   78 1.40146 79 1.40806 80 1.41471 81 1.42138 82 1.42810 83 1.43486 \
-#   84 1.44165 85 1.44848 86 1.45535 87 1.46225 88 1.46919 89 1.47616 \
-#   90 1.48317 91 1.49022 92 1.49730 93 1.50442 94 1.51157 95 1.51876
+brix[0.99717g/cm^3]\
+    0 1.00000  1 1.00390  2 1.00780  3 1.01173  4 1.01569  5 1.01968 \
+    6 1.02369  7 1.02773  8 1.03180  9 1.03590 10 1.04003 11 1.04418 \
+   12 1.04837 13 1.05259 14 1.05683 15 1.06111 16 1.06542 17 1.06976 \
+   18 1.07413 19 1.07853 20 1.08297 21 1.08744 22 1.09194 23 1.09647 \
+   24 1.10104 25 1.10564 26 1.11027 27 1.11493 28 1.11963 29 1.12436 \
+   30 1.12913 31 1.13394 32 1.13877 33 1.14364 34 1.14855 35 1.15350 \
+   36 1.15847 37 1.16349 38 1.16853 39 1.17362 40 1.17874 41 1.18390 \
+   42 1.18910 43 1.19434 44 1.19961 45 1.20491 46 1.21026 47 1.21564 \
+   48 1.22106 49 1.22652 50 1.23202 51 1.23756 52 1.24313 53 1.24874 \
+   54 1.25439 55 1.26007 56 1.26580 57 1.27156 58 1.27736 59 1.28320 \
+   60 1.28909 61 1.29498 62 1.30093 63 1.30694 64 1.31297 65 1.31905 \
+   66 1.32516 67 1.33129 68 1.33748 69 1.34371 70 1.34997 71 1.35627 \
+   72 1.36261 73 1.36900 74 1.37541 75 1.38187 76 1.38835 77 1.39489 \
+   78 1.40146 79 1.40806 80 1.41471 81 1.42138 82 1.42810 83 1.43486 \
+   84 1.44165 85 1.44848 86 1.45535 87 1.46225 88 1.46919 89 1.47616 \
+   90 1.48317 91 1.49022 92 1.49730 93 1.50442 94 1.51157 95 1.51876
 
 # Density measure invented by the American Petroleum Institute.  Lighter
 # petroleum products are more valuable, and they get a higher API degree.
 #
 # The intervals of range and domain should be open rather than closed.
 #
-#apidegree(x) units=[1;g/cm^3] domain=[-131.5,) range=[0,) \
-#                              141.5 g/cm^3 / (x+131.5) ; \
-#                              141.5 (g/cm^3) / apidegree + (-131.5)
+apidegree(x) units=[1;g/cm^3] domain=[-131.5,) range=[0,) \
+                              141.5 g/cm^3 / (x+131.5) ; \
+                              141.5 (g/cm^3) / apidegree + (-131.5)
+#
+# Average densities of various woods (dried)
+# Data from The Wood Database https://www.wood-database.com
+#
+
+# North American Hardwoods
+
+wood_cherry             35 lb/ft^3
+wood_redoak             44 lb/ft^3
+wood_whiteoak           47 lb/ft^3
+wood_blackwalnut        38 lb/ft^3
+wood_walnut             wood_blackwalnut
+wood_birch              43 lb/ft^3
+wood_hardmaple          44 lb/ft^3
+
+wood_bigleafmaple       34 lb/ft^3
+wood_boxeldermaple      30 lb/ft^3
+wood_redmaple           38 lb/ft^3
+wood_silvermaple        33 lb/ft^3
+wood_stripedmaple       32 lb/ft^3
+wood_softmaple         (wood_bigleafmaple \
+                      + wood_boxeldermaple \
+                      + wood_redmaple \
+                      + wood_silvermaple \
+                      + wood_stripedmaple) / 5
+wood_poplar             29 lb/ft^3
+wood_beech              45 lb/ft^3
+
+# North American Softwoods
+
+wood_jeffreypine        28 lb/ft^3
+wood_ocotepine	        44 lb/ft^3
+wood_ponderosapine      28 lb/ft^3
+
+wood_loblollypine       35 lb/ft^3
+wood_longleafpine       41 lb/ft^3
+wood_shortleafpine      35 lb/ft^3
+wood_slashpine    	41 lb/ft^3
+wood_yellowpine        (wood_loblollypine \
+                      + wood_longleafpine \
+                      + wood_shortleafpine \
+                      + wood_slashpine) / 4
+wood_redpine            34 lb/ft^3
+
+wood_easternwhitepine   25 lb/ft^3
+wood_westernwhitepine   27 lb/ft^3
+wood_whitepine         (wood_easternwhitepine + wood_westernwhitepine) / 2
+
+wood_douglasfir         32 lb/ft^3
+
+wood_blackspruce        28 lb/ft^3
+wood_engelmannspruce    24 lb/ft^3
+wood_redspruce          27 lb/ft^3
+wood_sitkaspruce        27 lb/ft^3
+wood_whitespruce        27 lb/ft^3
+wood_spruce            (wood_blackspruce \
+                      + wood_engelmannspruce \
+                      + wood_redspruce \
+                      + wood_sitkaspruce \
+                      + wood_whitespruce) / 5
+
+# Other woods 
+
+wood_basswood           26 lb/ft^3
+wood_balsa               9 lb/ft^3
+wood_ebony_gaboon       60 lb/ft^3
+wood_ebony_macassar     70 lb/ft^3
+wood_mahogany           37 lb/ft^3   # True (Honduran) mahogany,
+                                     # Swietenia macrophylla
+wood_teak               41 lb/ft^3   
+wood_rosewood_brazilian 52 lb/ft^3
+wood_rosewood_honduran  64 lb/ft^3
+wood_rosewood_indian    52 lb/ft^3
+wood_cocobolo           69 lb/ft^3          
+wood_bubinga            56 lb/ft^3
+wood_zebrawood          50 lb/ft^3
+wood_koa                38 lb/ft^3
+wood_snakewood          75.7 lb/ft^3
+wood_lignumvitae        78.5 lb/ft^3
+wood_blackwood          79.3 lb/ft^3
+wood_blackironwood      84.5 lb/ft^3 # Krugiodendron ferreum, listed
+                                     #   in database as the heaviest wood
+
+#
+# Modulus of elasticity of selected woods.
+# Data from The Wood Database https://www.wood-database.com
+#
+
+# North American Hardwoods
+
+wood_mod_beech              1.720e6 lbf/in^2
+wood_mod_birchyellow        2.010e6 lbf/in^2
+wood_mod_birch              wood_mod_birchyellow
+wood_mod_cherry             1.490e6 lbf/in^2
+wood_mod_hardmaple          1.830e6 lbf/in^2
+
+wood_mod_bigleafmaple       1.450e6 lbf/in^2
+wood_mod_boxeldermaple      1.050e6 lbf/in^2
+wood_mod_redmaple           1.640e6 lbf/in^2
+wood_mod_silvermaple        1.140e6 lbf/in^2
+wood_mod_softmaple         (wood_mod_bigleafmaple \
+                          + wood_mod_boxeldermaple \
+			  + wood_mod_redmaple \
+                          + wood_mod_silvermaple) / 4
+
+wood_mod_redoak             1.761e6 lbf/in^2
+wood_mod_whiteoak           1.762e6 lbf/in^2
+wood_mod_poplar             1.580e6 lbf/in^2
+wood_mod_blackwalnut        1.680e6 lbf/in^2
+wood_mod_walnut             wood_mod_blackwalnut
+
+# North American Softwoods
+
+wood_mod_jeffreypine        1.240e6 lbf/in^2
+wood_mod_ocotepine          2.209e6 lbf/in^2
+wood_mod_ponderosapine      1.290e6 lbf/in^2
+
+wood_mod_loblollypine	    1.790e6 lbf/in^2
+wood_mod_longleafpine       1.980e6 lbf/in^2
+wood_mod_shortleafpine      1.750e6 lbf/in^2
+wood_mod_slashpine	    1.980e6 lbf/in^2
+wood_mod_yellowpine        (wood_mod_loblollypine \
+                          + wood_mod_longleafpine \
+                          + wood_mod_shortleafpine \
+                          + wood_mod_slashpine) / 4
+
+wood_mod_redpine            1.630e6 lbf/in^2
+
+wood_mod_easternwhitepine   1.240e6 lbf/in^2
+wood_mod_westernwhitepine   1.460e6 lbf/in^2
+wood_mod_whitepine         (wood_mod_easternwhitepine + \
+                            wood_mod_westernwhitepine) / 2
+
+wood_mod_douglasfir         1.765e6  lbf/in^2
+
+wood_mod_blackspruce        1.523e6 lbf/in^2
+wood_mod_englemannspruce    1.369e6 lbf/in^2
+wood_mod_redspruce          1.560e6 lbf/in^2
+wood_mod_sitkaspruce        1.600e6 lbf/in^2
+wood_mod_whitespruce        1.315e6 lbf/in^2
+wood_mod_spruce            (wood_mod_blackspruce \
+                          + wood_mod_englemannspruce \
+                          + wood_mod_redspruce + wood_mod_sitkaspruce \
+		          + wood_mod_whitespruce) / 5
+
+# Other woods 
+
+wood_mod_balsa              0.538e6 lbf/in^2
+wood_mod_basswood           1.460e6 lbf/in^2
+wood_mod_blackwood          2.603e6 lbf/in^2  # African, Dalbergia melanoxylon
+wood_mod_bubinga            2.670e6 lbf/in^2
+wood_mod_cocobolo           2.712e6 lbf/in^2
+wood_mod_ebony_gaboon       2.449e6 lbf/in^2
+wood_mod_ebony_macassar     2.515e6 lbf/in^2
+wood_mod_blackironwood      2.966e6 lbf/in^2  # Krugiodendron ferreum
+wood_mod_koa                1.503e6 lbf/in^2
+wood_mod_lignumvitae        2.043e6 lbf/in^2
+wood_mod_mahogany           1.458e6 lbf/in^2  # True (Honduran) mahogany,
+                                              # Swietenia macrophylla
+wood_mod_rosewood_brazilian 2.020e6 lbf/in^2
+wood_mod_rosewood_honduran  3.190e6 lbf/in^2
+wood_mod_rosewood_indian    1.668e6 lbf/in^2
+wood_mod_snakewood          3.364e6 lbf/in^2
+wood_mod_teak               1.781e6 lbf/in^2
+wood_mod_zebrawood          2.374e6 lbf/in^2
+
+#
+# Area of countries and other regions.  This is the "total area" which
+# includes land and water areas within international boundaries and
+# coastlines.  Data from January, 2019.  
+#
+# except as noted, sources are
+# https://en.wikipedia.org/wiki/List_of_countries_and_dependencies_by_area
+# https://www.cia.gov/library/publications/the-world-factbook)
+
+area_russia              17098246 km^2
+area_antarctica          14000000 km^2
+# area_canada is covered below as sum of province and territory areas
+area_china                9596961 km^2
+# area_unitedstates is covered below as sum of state areas
+# includes only the 50 states and District of Columbia
+area_us                   area_unitedstates
+area_brazil               8515767 km^2
+area_australia            7692024 km^2
+# area_europeanunion is covered below as sum of member areas
+area_india                3287263 km^2
+area_argentina            2780400 km^2
+area_kazakhstan           2724900 km^2
+area_algeria              2381741 km^2
+area_drcongo              2344858 km^2
+area_greenland            2166086 km^2
+area_saudiarabia          2149690 km^2
+area_mexico               1964375 km^2
+area_indonesia            1910931 km^2
+area_sudan                1861484 km^2
+area_libya                1759540 km^2
+area_iran                 1648195 km^2
+area_mongolia             1564110 km^2
+area_peru                 1285216 km^2
+area_chad                 1284000 km^2
+area_niger                1267000 km^2
+area_angola               1246700 km^2
+area_mali                 1240192 km^2
+area_southafrica          1221037 km^2
+area_colombia             1141748 km^2
+area_ethiopia             1104300 km^2
+area_bolivia              1098581 km^2
+area_mauritania           1030700 km^2
+area_egypt                1002450 km^2
+area_tanzania              945087 km^2
+area_nigeria               923768 km^2
+area_venezuela             916445 km^2
+area_pakistan              881912 km^2
+area_namibia               825615 km^2
+area_mozambique            801590 km^2
+area_turkey                783562 km^2
+area_chile                 756102 km^2
+area_zambia                752612 km^2
+area_myanmar               676578 km^2
+area_burma                area_myanmar
+area_afghanistan           652230 km^2
+area_southsudan            644329 km^2
+area_france                640679 km^2
+area_somalia               637657 km^2
+area_centralafrica         622984 km^2
+area_ukraine               603500 km^2
+area_crimea		    27000 km^2	# occupied by Russia; included in
+                                        # (Encyclopedia Britannica)
+area_madagascar            587041 km^2
+area_botswana              581730 km^2
+area_kenya                 580367 km^2
+area_yemen                 527968 km^2
+area_thailand              513120 km^2
+area_spain                 505992 km^2
+area_turkmenistan          488100 km^2
+area_cameroon              475422 km^2
+area_papuanewguinea        462840 km^2
+area_sweden                450295 km^2
+area_uzbekistan            447400 km^2
+area_morocco               446550 km^2
+area_iraq                  438317 km^2
+area_paraguay              406752 km^2
+area_zimbabwe              390757 km^2
+area_japan                 377973 km^2
+area_germany               357114 km^2
+area_congorepublic         342000 km^2
+area_finland               338424 km^2
+area_vietnam               331212 km^2
+area_malaysia              330803 km^2
+area_norway                323802 km^2
+area_ivorycoast            322463 km^2
+area_poland                312696 km^2
+area_oman                  309500 km^2
+area_italy                 301339 km^2
+area_philippines           300000 km^2
+area_ecuador               276841 km^2
+area_burkinafaso           274222 km^2
+area_newzealand            270467 km^2
+area_gabon                 267668 km^2
+area_westernsahara         266000 km^2
+area_guinea                245857 km^2
+# area_unitedkingdom is covered below
+area_uganda                241550 km^2
+area_ghana                 238533 km^2
+area_romania               238397 km^2
+area_laos                  236800 km^2
+area_guyana                214969 km^2
+area_belarus               207600 km^2
+area_kyrgyzstan            199951 km^2
+area_senegal               196722 km^2
+area_syria                 185180 km^2
+area_golanheights	     1150 km^2	# occupied by Israel; included in 
+                                        # Syria (Encyclopedia Britannica)
+area_cambodia              181035 km^2
+area_uruguay               176215 km^2
+area_somaliland            176120 km^2
+area_suriname              163820 km^2
+area_tunisia               163610 km^2
+area_bangladesh            147570 km^2
+area_nepal                 147181 km^2
+area_tajikistan            143100 km^2
+area_greece                131990 km^2
+area_nicaragua             130373 km^2
+area_northkorea            120540 km^2
+area_malawi                118484 km^2
+area_eritrea               117600 km^2
+area_benin                 114763 km^2
+area_honduras              112492 km^2
+area_liberia               111369 km^2
+area_bulgaria              110879 km^2
+area_cuba                  109884 km^2
+area_guatemala             108889 km^2
+area_iceland               103000 km^2
+area_southkorea            100210 km^2
+area_hungary                93028 km^2
+area_portugal               92090 km^2
+area_jordan                 89342 km^2
+area_serbia                 88361 km^2
+area_azerbaijan             86600 km^2
+area_austria                83871 km^2
+area_uae                    83600 km^2
+area_czechia                78865 km^2
+area_czechrepublic         area_czechia
+area_panama                 75417 km^2
+area_sierraleone            71740 km^2
+area_ireland                70273 km^2
+area_georgia                69700 km^2
+area_srilanka               65610 km^2
+area_lithuania              65300 km^2
+area_latvia                 64559 km^2
+area_togo                   56785 km^2
+area_croatia                56594 km^2
+area_bosnia                 51209 km^2
+area_costarica              51100 km^2
+area_slovakia               49037 km^2
+area_dominicanrepublic      48671 km^2
+area_estonia                45227 km^2
+area_denmark                43094 km^2
+area_netherlands            41850 km^2
+area_switzerland            41284 km^2
+area_bhutan                 38394 km^2
+area_taiwan                 36193 km^2
+area_guineabissau           36125 km^2
+area_moldova                33846 km^2
+area_belgium                30528 km^2
+area_lesotho                30355 km^2
+area_armenia                29743 km^2
+area_solomonislands         28896 km^2
+area_albania                28748 km^2
+area_equitorialguinea       28051 km^2
+area_burundi                27834 km^2
+area_haiti                  27750 km^2
+area_rwanda                 26338 km^2
+area_northmacedonia         25713 km^2
+area_djibouti               23200 km^2
+area_belize                 22966 km^2
+area_elsalvador             21041 km^2
+area_israel                 20770 km^2
+area_slovenia               20273 km^2
+area_fiji                   18272 km^2
+area_kuwait                 17818 km^2
+area_eswatini               17364 km^2
+area_easttimor              14919 km^2
+area_bahamas                13943 km^2
+area_montenegro             13812 km^2
+area_vanatu                 12189 km^2
+area_qatar                  11586 km^2
+area_gambia                 11295 km^2
+area_jamaica                10991 km^2
+area_kosovo                 10887 km^2
+area_lebanon                10452 km^2
+area_cyprus                  9251 km^2
+area_puertorico              9104 km^2	# United States territory; not included
+                                        #   in United States area
+area_westbank                5860 km^2	# (CIA World Factbook)
+area_hongkong                2755 km^2
+area_luxembourg              2586 km^2
+area_singapore                716 km^2
+area_gazastrip                360 km^2	# (CIA World Factbook)
+area_malta                    316 km^2  # smallest EU country
+area_liechtenstein            160 km^2
+area_monaco                     2.02 km^2
+area_vaticancity                0.44 km^2
+
+# Members as of 1 Feb 2020
+area_europeanunion        area_austria + area_belgium + area_bulgaria \
+			+ area_croatia + area_cyprus + area_czechia + area_denmark \
+                        + area_estonia + area_finland + area_france + area_germany \
+                        + area_greece + area_hungary + area_ireland + area_italy \
+                        + area_latvia + area_lithuania + area_luxembourg \
+                        + area_malta + area_netherlands + area_poland \
+                        + area_portugal + area_romania + area_slovakia \
+                        + area_slovenia + area_spain + area_sweden
+area_eu                   area_europeanunion
+
+#
+# Areas of the individual US states
+#
+# https://en.wikipedia.org/wiki/List_of_U.S._states_and_territories_by_area
+#
+# United States Summary: 2010, Population and Housing Unit Counts, Table 18, p. 41
+# Issued September 2012
+
+area_alaska               1723336.8 km^2
+area_texas                 695661.6 km^2
+area_california            423967.4 km^2
+area_montana               380831.1 km^2
+area_newmexico             314917.4 km^2
+area_arizona               295233.5 km^2
+area_nevada                286379.7 km^2
+area_colorado              269601.4 km^2
+area_oregon                254799.2 km^2
+area_wyoming               253334.5 km^2
+area_michigan              250486.8 km^2
+area_minnesota             225162.8 km^2
+area_utah                  219881.9 km^2
+area_idaho                 216442.6 km^2
+area_kansas                213100.0 km^2
+area_nebraska              200329.9 km^2
+area_southdakota           199728.7 km^2
+area_washington            184660.8 km^2
+area_northdakota           183107.8 km^2
+area_oklahoma              181037.2 km^2
+area_missouri              180540.3 km^2
+area_florida               170311.7 km^2
+area_wisconsin             169634.8 km^2
+area_georgia_us            153910.4 km^2
+area_illinois              149995.4 km^2
+area_iowa                  145745.9 km^2
+area_newyork               141296.7 km^2
+area_northcarolina         139391.0 km^2
+area_arkansas              137731.8 km^2
+area_alabama               135767.4 km^2
+area_louisiana             135658.7 km^2
+area_mississippi           125437.7 km^2
+area_pennsylvania          119280.2 km^2
+area_ohio                  116097.7 km^2
+area_virginia              110786.6 km^2
+area_tennessee             109153.1 km^2
+area_kentucky              104655.7 km^2
+area_indiana                94326.2 km^2
+area_maine                  91633.1 km^2
+area_southcarolina          82932.7 km^2
+area_westvirginia           62755.5 km^2
+area_maryland               32131.2 km^2
+area_hawaii                 28313.0 km^2
+area_massachusetts          27335.7 km^2
+area_vermont                24906.3 km^2
+area_newhampshire           24214.2 km^2
+area_newjersey              22591.4 km^2
+area_connecticut            14357.4 km^2
+area_delaware                6445.8 km^2
+area_rhodeisland             4001.2 km^2
+area_districtofcolumbia       177.0 km^2
+
+area_unitedstates          area_alabama + area_alaska + area_arizona \
+                         + area_arkansas + area_california + area_colorado \
+                         + area_connecticut + area_delaware \
+                         + area_districtofcolumbia + area_florida \
+                         + area_georgia_us + area_hawaii + area_idaho \
+                         + area_illinois + area_indiana + area_iowa \
+                         + area_kansas + area_kentucky + area_louisiana \
+                         + area_maine + area_maryland + area_massachusetts \
+                         + area_michigan + area_minnesota + area_mississippi \
+                         + area_missouri + area_montana + area_nebraska \
+                         + area_nevada + area_newhampshire + area_newjersey \
+                         + area_newmexico + area_newyork + area_northcarolina \
+                         + area_northdakota + area_ohio + area_oklahoma \
+                         + area_oregon + area_pennsylvania + area_rhodeisland \
+                         + area_southcarolina + area_southdakota \
+                         + area_tennessee + area_texas + area_utah \
+                         + area_vermont + area_virginia + area_washington \
+                         + area_westvirginia + area_wisconsin + area_wyoming
+
+# Total area of Canadian province and territories
+#
+# Statistics Canada, "Land and freshwater area, by province and territory",
+# 2016-10-07:
+#
+# https://www150.statcan.gc.ca/n1/pub/11-402-x/2012000/chap/geo/tbl/tbl06-eng.htm
+
+area_ontario                    1076395 km^2    # confederated 1867-Jul-01
+area_quebec                     1542056 km^2    # confederated 1867-Jul-01
+area_novascotia                 55284 km^2      # confederated 1867-Jul-01
+area_newbrunswick               72908 km^2      # confederated 1867-Jul-01
+area_canada_original            area_ontario + area_quebec + area_novascotia \
+                                             + area_newbrunswick
+area_manitoba                   647797 km^2     # confederated 1870-Jul-15
+area_britishcolumbia            944735 km^2     # confederated 1871-Jul-20
+area_princeedwardisland         5660 km^2       # confederated 1873-Jul-01
+area_canada_additional          area_manitoba + area_britishcolumbia \
+                                              + area_princeedwardisland
+area_alberta                    661848 km^2     # confederated 1905-Sep-01
+area_saskatchewan               651036 km^2     # confederated 1905-Sep-01
+area_newfoundlandandlabrador    405212 km^2     # confederated 1949-Mar-31
+area_canada_recent              area_alberta + area_saskatchewan \
+                                             + area_newfoundlandandlabrador
+area_canada_provinces           area_canada_original + area_canada_additional \
+                                                     + area_canada_recent
+area_northwestterritories       1346106 km^2    # NT confederated 1870-Jul-15
+area_yukon                      482443 km^2     # YT confederated 1898-Jun-13
+area_nunavut                    2093190 km^2    # NU confederated 1999-Apr-01
+area_canada_territories         area_northwestterritories + area_yukon \
+                                              + area_nunavut
+area_canada                     area_canada_provinces + area_canada_territories
+
+# area-uk-countries.units - UK country (/province) total areas
+# https://en.wikipedia.org/wiki/Countries_of_the_United_Kingdom#Statistics
+# GB is official UK country code for some purposes but internally is a Kingdom
+#
+# areas from A Beginners Guide to UK Geography 2019 v1.0, Office for National Statistics
+# England: country; 0927-Jul-12 united; 1603-Mar-24 union of crowns
+area_england            132947.76 km^2
+#
+# Wales: 1282 conquered; 1535 union; principality until 2011
+area_wales              21224.48 km^2
+#
+# England and Wales: nation; 1535 union
+area_englandwales       area_england + area_wales
+#
+# Scotland: country; ~900 united; 1603-Mar-24 union of crowns
+area_scotland           80226.36 km^2
+#
+# Great Britain: kingdom; excludes NI;
+# 1707 Treaty and Acts of Union: union of parliaments
+area_greatbritain       area_england + area_wales + area_scotland
+area_gb                 area_greatbritain
+#
+# Northern Ireland: province; Ireland: 1177 Henry II lordship;
+# 1542 Henry VIII kingdom; 1652 Cromwell commonwealth;
+# 1691 William III kingdom; 1800 Acts of Union: UK of GB & Ireland;
+# 1921 Irish Free State independent of UK
+area_northernireland    14133.38 km^2
+#
+# United Kingdom of GB & NI: 1800 Acts of Union: UK of GB & Ireland;
+# 1921 Irish Free State independent of UK
+area_unitedkingdom      area_greatbritain + area_northernireland
+area_uk                 area_unitedkingdom
 
 #
 # Units derived from imperial system
 #
-
-!category derived_customary "Derived Customary Units"
 
 ouncedal                oz ft / s^2     # force which accelerates an ounce
                                         #    at 1 ft/s^2
@@ -2902,9 +4332,9 @@ pdl                     poundal
 osi                     ounce force / inch^2   # used in aviation
 psi                     pound force / inch^2
 psia                    psi             # absolute pressure
-					#   Note that gauge pressure can be given
-					#   using the gaugepressure() and
-					#   psig() nonlinear unit definitions
+                                        #   Note that gauge pressure can be given
+                                        #   using the gaugepressure() and
+                                        #   psig() nonlinear unit definitions
 tsi                     ton force / inch^2
 reyn                    psi sec
 slug                    lbf s^2 / ft
@@ -2957,7 +4387,7 @@ beespace               1|4 inch      # Bees will fill any space that is smaller
                                      #   than the bee space and leave open
                                      #   spaces that are larger.  The size of
                                      #   the space varies with species.
-tapediamond            8|5 ft        # Marking on US tape measures that is
+diamond                8|5 ft        # Marking on US tape measures that is
                                      #   useful to carpenters who wish to place
                                      #   five studs in an 8 ft distance.  Note
                                      #   that the numbers appear in red every
@@ -2974,56 +4404,241 @@ RU                     U             #   than its U measurement indicates to
                                      #   called the Electronic Industries
                                      #   Alliance (EIA) and the rack standard
                                      #   is specified in EIA RS-310-D.
-count                  /pound        # For measuring the size of shrimp
-
-!endcategory
+count                  per pound     # For measuring the size of shrimp
+flightlevel            100 ft        # Flight levels are used to ensure safe
+FL                     flightlevel   #   vertical separation between aircraft
+                                     #   despite variations in local air
+                                     #   pressure.  Flight levels define
+                                     #   altitudes based on a standard air
+                                     #   pressure so that altimeter calibration
+                                     #   is not needed.  This means that
+                                     #   aircraft at separated flight levels
+                                     #   are guaranteed to be separated.
+                                     #   Hence the definition of 100 feet is
+                                     #   a nominal, not true, measure.
+                                     #   Customarily written with no space in
+                                     #   the form FL290, which will not work in
+                                     #   units.  But note "FL 290" will work.  
 
 #
 # Other units of work, energy, power, etc
 #
 
-energy                  ? joule
+ENERGY                  joule
+WORK                    joule
 
-# Calories: energy to raise a gram of water one degree celsius
+# Calorie: approximate energy to raise a gram of water one degree celsius
 
-!category calories "Calories"
-
-cal_IT                  4.1868 J     # International Table calorie
-cal_th                  4.184 J      # Thermochemical calorie
-cal_fifteen             4.18580 J    # Energy to go from 14.5 to 15.5 degC
-cal_twenty              4.18190 J    # Energy to go from 19.5 to 20.5 degC
-cal_mean                4.19002 J    # 1|100 energy to go from 0 to 100 degC
-calorie                 cal_IT
+calorie                 cal_th       # Default is the thermochemical calorie
 cal                     calorie
-calorie_IT              cal_IT
-thermcalorie            cal_th
-calorie_th              thermcalorie
+calorie_th              4.184 J      # Thermochemical calorie, defined in 1930
+thermcalorie            calorie_th   #   by Frederick Rossini as 4.1833 J to 
+cal_th                  calorie_th   #   avoid difficulties associated with the 
+                                     #   uncertainty in the heat capacity of 
+                                     #   water.  In 1948 the value of the joule 
+                                     #   was changed, so the thermochemical
+                                     #   calorie was redefined to 4.184 J.
+                                     #   This kept the energy measured by this
+                                     #   unit the same. 
+calorie_IT              4.1868 J     # International (Steam) Table calorie,
+cal_IT                  calorie_IT   #   defined in 1929 as watt-hour/860 or
+                                     #   equivalently 180|43 joules.  At this
+                                     #   time the international joule had a
+                                     #   different value than the modern joule,
+                                     #   and the values were different in the
+                                     #   USA and in Europe.  In 1956 at the
+                                     #   Fifth International Conference on
+                                     #   Properties of Steam the exact
+                                     #   definition given here was adopted. 
+calorie_15              4.18580 J    # Energy to go from 14.5 to 15.5 degC
+cal_15                  calorie_15
+calorie_fifteen         cal_15
+calorie_20              4.18190 J    # Energy to go from 19.5 to 20.5 degC
+cal_20                  calorie_20
+calorie_twenty          calorie_20
+calorie_4               4.204 J      # Energy to go from 3.5 to 4.5 degC
+cal_4                   calorie_4
+calorie_four            calorie_4
+cal_mean                4.19002 J    # 1|100 energy to go from 0 to 100 degC
 Calorie                 kilocalorie  # the food Calorie
-thermie              1e6 cal_fifteen # Heat required to raise the
+thermie              1e6 cal_15      # Heat required to raise the
                                      # temperature of a tonne of
                                      # water from 14.5 to 15.5 degC.
 
-!endcategory
-
 # btu definitions: energy to raise a pound of water 1 degF
 
-btu                     cal lb degR / gram K # international table BTU
+btu                     btu_IT       # International Table BTU is the default
 britishthermalunit      btu
-btu_IT                  btu
-btu_th                  cal_th lb degR / gram K
-btu_mean                cal_mean lb degR / gram K
+btu_IT                  cal_IT lb degF / gram K
+btu_th                  cal_th lb degF / gram K
+btu_mean                cal_mean lb degF / gram K
+btu_15                  cal_15 lb degF / gram K
+btu_ISO                 1055.06 J    # Exact, rounded ISO definition based
+                                     #    on the IT calorie
 quad                    quadrillion btu
 
-ECtherm                 1.05506e8 J    # Exact definition, close to 1e5 btu
-UStherm                 1.054804e8 J   # Exact definition
+ECtherm                 1e5 btu_ISO    # Exact definition
+UStherm                 1.054804e8 J   # Exact definition, 
 therm                   UStherm
+
+# Water latent heat from [23]
+
+water_fusion_heat       6.01 kJ/mol / (18.015 g/mol) # At 0 deg C
+water_vaporization_heat 2256.4 J/g  # At saturation, 100 deg C, 101.42 kPa
+
+# Specific heat capacities of various substances
+
+specificheat_water      calorie / g K
+water_specificheat      specificheat_water
+     # Values from www.engineeringtoolbox.com/specific-heat-metals-d_152.html
+specificheat_aluminum   0.91 J/g K
+specificheat_antimony   0.21 J/g K
+specificheat_barium     0.20 J/g K
+specificheat_beryllium  1.83 J/g K
+specificheat_bismuth    0.13 J/g K
+specificheat_cadmium    0.23 J/g K
+specificheat_cesium     0.24 J/g K
+specificheat_chromium   0.46 J/g K
+specificheat_cobalt     0.42 J/g K
+specificheat_copper     0.39 J/g K
+specificheat_gallium    0.37 J/g K
+specificheat_germanium  0.32 J/g K
+specificheat_gold       0.13 J/g K
+specificheat_hafnium    0.14 J/g K
+specificheat_indium     0.24 J/g K
+specificheat_iridium    0.13 J/g K
+specificheat_iron       0.45 J/g K
+specificheat_lanthanum  0.195 J/g K
+specificheat_lead       0.13 J/g K
+specificheat_lithium    3.57 J/g K
+specificheat_lutetium   0.15 J/g K
+specificheat_magnesium  1.05 J/g K
+specificheat_manganese  0.48 J/g K
+specificheat_mercury    0.14 J/g K
+specificheat_molybdenum 0.25 J/g K
+specificheat_nickel     0.44 J/g K
+specificheat_osmium     0.13 J/g K
+specificheat_palladium  0.24 J/g K
+specificheat_platinum   0.13 J/g K
+specificheat_plutonum   0.13 J/g K
+specificheat_potassium  0.75 J/g K
+specificheat_rhenium    0.14 J/g K
+specificheat_rhodium    0.24 J/g K
+specificheat_rubidium   0.36 J/g K
+specificheat_ruthenium  0.24 J/g K
+specificheat_scandium   0.57  J/g K
+specificheat_selenium   0.32 J/g K
+specificheat_silicon    0.71 J/g K
+specificheat_silver     0.23 J/g K
+specificheat_sodium     1.21 J/g K
+specificheat_strontium  0.30 J/g K
+specificheat_tantalum   0.14 J/g K
+specificheat_thallium   0.13 J/g K
+specificheat_thorium    0.13 J/g K
+specificheat_tin        0.21 J/g K
+specificheat_titanium   0.54 J/g K
+specificheat_tungsten   0.13 J/g K
+specificheat_uranium    0.12 J/g K
+specificheat_vanadium   0.39 J/g K
+specificheat_yttrium    0.30 J/g K
+specificheat_zinc       0.39 J/g K
+specificheat_zirconium  0.27 J/g K
+specificheat_ethanol    2.3  J/g K
+specificheat_ammonia    4.6 J/g K
+specificheat_freon      0.91 J/g K   # R-12 at 0 degrees Fahrenheit
+specificheat_gasoline   2.22 J/g K
+specificheat_iodine     2.15 J/g K
+specificheat_oliveoil   1.97 J/g K
+
+#  en.wikipedia.org/wiki/Heat_capacity#Table_of_specific_heat_capacities
+specificheat_hydrogen   14.3 J/g K
+specificheat_helium     5.1932 J/g K
+specificheat_argon      0.5203 J/g K
+specificheat_tissue     3.5 J/g K
+specificheat_diamond    0.5091 J/g K
+specificheat_granite    0.79 J/g K
+specificheat_graphite   0.71 J/g K
+specificheat_ice        2.11 J/g K
+specificheat_asphalt    0.92 J/g K
+specificheat_brick      0.84 J/g K
+specificheat_concrete   0.88 J/g K
+specificheat_glass_silica 0.84 J/g K
+specificheat_glass_flint  0.503 J/g K
+specificheat_glass_pyrex  0.753 J/g K
+specificheat_gypsum     1.09 J/g K
+specificheat_marble     0.88 J/g K
+specificheat_sand       0.835 J/g K
+specificheat_soil       0.835 J/g K
+specificheat_wood       1.7 J/g K
+
+specificheat_sucrose    1.244 J/g K #www.sugartech.co.za/heatcapacity/index.php
+
+
+# Energy densities of various fuels
+#
+# Most of these fuels have varying compositions or qualities and hence their
+# actual energy densities vary.  These numbers are hence only approximate.
+#
+# E1. http://bioenergy.ornl.gov/papers/misc/energy_conv.html
+# E2. http://www.aps.org/policy/reports/popa-reports/energy/units.cfm
+# E3. http://www.ior.com.au/ecflist.html
+
+tonoil                  1e10 cal_IT    # Ton oil equivalent.  A conventional
+                                       # value for the energy released by
+toe                     tonoil         # burning one metric ton of oil. [18,E2]
+                                       # Note that energy per mass of petroleum
+                                       # products is fairly constant.
+                                       # Variations in volumetric energy
+                                       # density result from variations in the
+                                       # density (kg/m^3) of different fuels.
+                                       # This definition is given by the
+                                       # IEA/OECD.
+toncoal                 7e9 cal_IT     # Energy in metric ton coal from [18].
+                                       # This is a nominal value which
+                                       # is close to the heat content
+                                       # of coal used in the 1950's
+barreloil               5.8 Mbtu       # Conventional value for barrel of crude
+                                       # oil [E2].  Actual range is 5.6 - 6.3.
+naturalgas_HHV          1027 btu/ft3   # Energy content of natural gas.  HHV
+naturalgas_LHV          930 btu/ft3    # is for Higher Heating Value and
+naturalgas              naturalgas_HHV # includes energy from condensation
+                                       # combustion products.  LHV is for Lower
+                                       # Heating Value and excludes these.
+                                       # American publications typically report
+                                       # HHV whereas European ones report LHV.
+charcoal                30 GJ/tonne
+woodenergy_dry          20 GJ/tonne    # HHV, a cord weights about a tonne
+woodenergy_airdry       15 GJ/tonne    # 20% moisture content
+coal_bituminous         27 GJ / tonne
+coal_lignite            15 GJ / tonne
+coal_US                 22 GJ / uston  # Average for US coal (short ton), 1995
+ethanol_HHV         84000 btu/usgallon
+ethanol_LHV         75700 btu/usgallon
+diesel             130500 btu/usgallon
+gasoline_LHV       115000 btu/usgallon
+gasoline_HHV       125000 btu/usgallon
+gasoline                gasoline_HHV
+heating                 37.3 MJ/liter
+fueloil                 39.7 MJ/liter  # low sulphur
+propane                 93.3 MJ/m^3
+butane                  124 MJ/m^3
+
+# These values give total energy from uranium fission.  Actual efficiency
+# of nuclear power plants is around 30%-40%.  Note also that some reactors
+# use enriched uranium around 3% U-235.  Uranium during processing or use
+# may be in a compound of uranium oxide or uranium hexafluoride, in which
+# case the energy density would be lower depending on how much uranium is
+# in the compound.
+
+uranium_pure     200 MeV avogadro / (235.0439299 g/mol)  # Pure U-235
+uranium_natural         0.7% uranium_pure        # Natural uranium: 0.7% U-235
 
 # Celsius heat unit: energy to raise a pound of water 1 degC
 
-celsiusheatunit         cal lb K / gram K
+celsiusheatunit         cal lb degC / gram K
 chu                     celsiusheatunit
 
-power                   ? watt
+POWER                   watt
 
 # "Apparent" average power in an AC circuit, the product of rms voltage
 # and rms current, equal to the true power in watts when voltage and
@@ -3036,8 +4651,6 @@ kWh                     kilowatt hour
 # The horsepower is supposedly the power of one horse pulling.   Obviously
 # different people had different horses.
 
-!category horses "Horse Units"
-
 horsepower              550 foot pound force / sec    # Invented by James Watt
 mechanicalhorsepower    horsepower
 hp                      horsepower
@@ -3045,11 +4658,9 @@ metrichorsepower        75 kilogram force meter / sec # PS=Pferdestaerke in
 electrichorsepower      746 W                         # Germany
 boilerhorsepower        9809.50 W
 waterhorsepower         746.043 W
-brhorsepower            745.70 W
+brhorsepower            horsepower   # Value corrected Dec, 2019.  Was 745.7 W.
 donkeypower             250 W
 chevalvapeur            metrichorsepower
-
-!endcategory
 
 #
 # Heat Transfer
@@ -3061,37 +4672,48 @@ chevalvapeur            metrichorsepower
 # cross sectional area, t is the time, and L is the length (thickness).
 # Thermal conductivity is a material property.
 
-thermal_conductivity    ? power / area (temperature_difference/length)
-thermal_resistivity     ? 1/thermal_conductivity
+THERMAL_CONDUCTIVITY    POWER / AREA (TEMPERATURE_DIFFERENCE/LENGTH)
+THERMAL_RESISTIVITY     1/THERMAL_CONDUCTIVITY
 
 # Thermal conductance is the rate at which heat flows across a given
 # object, so the area and thickness have been fixed.  It depends on
 # the size of the object and is hence not a material property.
 
-thermal_conductance     ? power / temperature_difference
-thermal_resistance      ? 1/thermal_conductance
+THERMAL_CONDUCTANCE     POWER / TEMPERATURE_DIFFERENCE
+THERMAL_RESISTANCE      1/THERMAL_CONDUCTANCE
 
 # Thermal admittance is the rate of heat flow per area across an
 # object whose thickness has been fixed.  Its reciprocal, thermal
 # insulation, is used to for measuring the heat transfer per area
 # of sheets of insulation or cloth that are of specified thickness.
 
-thermal_admittance      ? thermal_conductivity / length
-thermal_insulance         thermal_resistivity length
-thermal_insulation      ? thermal_resistivity length
+THERMAL_ADMITTANCE      THERMAL_CONDUCTIVITY / LENGTH
+THERMAL_INSULANCE       THERMAL_RESISTIVITY LENGTH
+THERMAL_INSULATION      THERMAL_RESISTIVITY LENGTH
 
-Rvalue                  degR ft^2 hr / btu
+Rvalue                  degF ft^2 hr / btu
 Uvalue                  1/Rvalue
 europeanUvalue          watt / m^2 K
-RSI                     K m^2 / W
-clo                     0.155 K m^2 / W # Supposed to be the insulance
+RSI                     degC m^2 / W
+clo                     0.155 degC m^2 / W # Supposed to be the insulance
                                            # required to keep a resting person
                                            # comfortable indoors.  The value
                                            # given is from NIST and the CRC,
                                            # but [5] gives a slightly different
                                            # value of 0.875 ft^2 degF hr / btu.
-tog                     0.1 K m^2 / W   # Also used for clothing.
+tog                     0.1 degC m^2 / W   # Also used for clothing.
 
+
+# Thermal Conductivity of a few materials
+
+diamond_natural_thermal_conductivity    2200 W / m K
+diamond_synthetic_thermal_conductivity  3320 W / m K  # 99% pure C12
+silver_thermal_conductivity             406 W / m K
+aluminum_thermal_conductivity           205 W / m K
+copper_thermal_conductivity             385 W / m K
+gold_thermal_conductivity               314 W / m K
+iron_thermal_conductivity               79.5 W / m K
+stainless_304_thermal_conductivity      15.5 W / m K  # average value
 
 # The bel was defined by engineers of Bell Laboratories to describe the
 # reduction in audio level over a length of one mile. It was originally
@@ -3101,15 +4723,15 @@ tog                     0.1 K m^2 / W   # Also used for clothing.
 # ratio, but it is used in various contexts to report a signal's power
 # relative to some reference level.
 
-#bel(x)     units=[1;1] range=(0,) 10^(x);    log(bel)    # Basic bel definition
-#decibel(x) units=[1;1] range=(0,) 10^(x/10); 10 log(decibel) # Basic decibel
-#dB()       decibel                                           # Abbreviation
-#dBW(x)     units=[1;W] range=(0,) dB(x) W ;  ~dB(dBW/W)      # Reference = 1 W
-#dBk(x)     units=[1;W] range=(0,) dB(x) kW ; ~dB(dBk/kW)     # Reference = 1 kW
-#dBf(x)     units=[1;W] range=(0,) dB(x) fW ; ~dB(dBf/fW)     # Reference = 1 fW
-#dBm(x)     units=[1;W] range=(0,) dB(x) mW ; ~dB(dBm/mW)     # Reference = 1 mW
-#dBmW(x)    units=[1;W] range=(0,) dBm(x) ;   ~dBm(dBmW)      # Reference = 1 mW
-#dBJ(x)     units=[1;J] range=(0,) dB(x) J; ~dB(dBJ/J)        # Energy relative
+bel(x)     units=[1;1] range=(0,) 10^(x);    log(bel)    # Basic bel definition
+decibel(x) units=[1;1] range=(0,) 10^(x/10); 10 log(decibel) # Basic decibel
+dB()       decibel                                           # Abbreviation
+dBW(x)     units=[1;W] range=(0,) dB(x) W ;  ~dB(dBW/W)      # Reference = 1 W
+dBk(x)     units=[1;W] range=(0,) dB(x) kW ; ~dB(dBk/kW)     # Reference = 1 kW
+dBf(x)     units=[1;W] range=(0,) dB(x) fW ; ~dB(dBf/fW)     # Reference = 1 fW
+dBm(x)     units=[1;W] range=(0,) dB(x) mW ; ~dB(dBm/mW)     # Reference = 1 mW
+dBmW(x)    units=[1;W] range=(0,) dBm(x) ;   ~dBm(dBmW)      # Reference = 1 mW
+dBJ(x)     units=[1;J] range=(0,) dB(x) J; ~dB(dBJ/J)        # Energy relative
                                      # to 1 joule.  Used for power spectral
                                      # density since W/Hz = J
 
@@ -3117,33 +4739,40 @@ tog                     0.1 K m^2 / W   # Also used for clothing.
 # because power is proportional to the square of these measures.  The root
 # mean square (RMS) voltage is typically used with these units.
 
-#dBV(x)  units=[1;V] range=(0,) dB(0.5 x) V;~dB(dBV^2 / V^2) # Reference = 1 V
-#dBmV(x) units=[1;V] range=(0,) dB(0.5 x) mV;~dB(dBmV^2/mV^2)# Reference = 1 mV
-#dBuV(x) units=[1;V] range=(0,) dB(0.5 x) microV ; ~dB(dBuV^2 / microV^2)
+dBV(x)  units=[1;V] range=(0,) dB(0.5 x) V;~dB(dBV^2 / V^2) # Reference = 1 V
+dBmV(x) units=[1;V] range=(0,) dB(0.5 x) mV;~dB(dBmV^2/mV^2)# Reference = 1 mV
+dBuV(x) units=[1;V] range=(0,) dB(0.5 x) microV ; ~dB(dBuV^2 / microV^2)
                                    # Reference = 1 microvolt
+
+# Here are dB measurements for current.  Be aware that dbA is also 
+# a unit for frequency weighted sound pressure.  
+dBA(x)  units=[1;A] range=(0,) dB(0.5 x) A;~dB(dBA^2 / A^2) # Reference = 1 A
+dBmA(x) units=[1;A] range=(0,) dB(0.5 x) mA;~dB(dBmA^2/mA^2)# Reference = 1 mA
+dBuA(x) units=[1;A] range=(0,) dB(0.5 x) microA ; ~dB(dBuA^2 / microA^2)
+                                                    # Reference = 1 microamp
 
 # Referenced to the voltage that causes 1 mW dissipation in a 600 ohm load.
 # Originally defined as dBv but changed to prevent confusion with dBV.
 # The "u" is for unloaded.
-#dBu(x) units=[1;V] range=(0,) dB(0.5 x) sqrt(mW 600 ohm) ; \
-#                              ~dB(dBu^2 / mW 600 ohm)
-#dBv(x) units=[1;V] range=(0,) dBu(x) ; ~dBu(dBv)  # Synonym for dBu
-
+dBu(x) units=[1;V] range=(0,) dB(0.5 x) sqrt(mW 600 ohm) ; \
+                              ~dB(dBu^2 / mW 600 ohm)
+dBv(x) units=[1;V] range=(0,) dBu(x) ; ~dBu(dBv)  # Synonym for dBu
 
 # Measurements for sound in air, referenced to the threshold of human hearing
 # Note that sound in other media typically uses 1 micropascal as a reference
 # for sound pressure.  Units dBA, dBB, dBC, refer to different frequency
 # weightings meant to approximate the human ear's response.
 
-#dBSPL(x) units=[1;Pa] range=(0,) dB(0.5 x) 20 microPa ;  \
-#                                 ~dB(dBSPL^2 / (20 microPa)^2) # pressure
-#dBSIL(x) units=[1;W/m^2] range=(0,) dB(x) 1e-12 W/m^2; \
-#                                    ~dB(dBSIL / (1e-12 W/m^2)) # intensity
-#dBSWL(x) units=[1;W] range=(0,) dB(x) 1e-12 W; ~dB(dBSWL/1e-12 W)
+dBSPL(x) units=[1;Pa] range=(0,) dB(0.5 x) 20 microPa ;  \
+                                 ~dB(dBSPL^2 / (20 microPa)^2) # pressure
+dBSIL(x) units=[1;W/m^2] range=(0,) dB(x) 1e-12 W/m^2; \
+                                    ~dB(dBSIL / (1e-12 W/m^2)) # intensity
+dBSWL(x) units=[1;W] range=(0,) dB(x) 1e-12 W; ~dB(dBSWL/1e-12 W)
 
 
 # Misc other measures
 
+ENTROPY                 ENERGY / TEMPERATURE
 clausius                1e3 cal/K       # A unit of physical entropy
 langley                 thermcalorie/cm^2    # Used in radiation theory
 poncelet                100 kg force m / s
@@ -3154,11 +4783,27 @@ tonrefrigeration        uston 144 btu / lb day # One ton refrigeration is
                                         # latent heat of 144 btu/lb.
 tonref                  tonrefrigeration
 refrigeration           tonref / ton
-frigorie                1000 cal_fifteen# Used in refrigeration engineering.
+frigorie                1000 cal_15     # Used in refrigeration engineering.
 tnt                     1e9 cal_th / ton# So you can write tons tnt. This
                                         # is a defined, not measured, value.
 airwatt                 8.5 (ft^3/min) inH2O # Measure of vacuum power as
                                              # pressure times air flow.
+
+# Nuclear weapon yields 
+
+davycrocket             10 ton tnt         # lightest US tactical nuclear weapon
+hiroshima               15.5 kiloton tnt   # Uranium-235 fission bomb
+nagasaki                21 kiloton tnt     # Plutonium-239 fission bomb
+fatman                  nagasaki
+littleboy               hiroshima
+ivyking                 500 kiloton tnt    # most powerful fission bomb
+castlebravo             15 megaton tnt     # most powerful US test
+tsarbomba		50 megaton tnt     # most powerful test ever: USSR,
+                                           # 30 October 1961
+b53bomb                 9 megaton tnt
+                 # http://rarehistoricalphotos.com/gadget-first-atomic-bomb/
+trinity                 18 kiloton tnt     # July 16, 1945
+gadget                  trinity
 
 #
 # Permeability: The permeability or permeance, n, of a substance determines
@@ -3171,7 +4816,7 @@ perm_0C                 grain / hr ft^2 inHg
 perm_zero               perm_0C
 perm_0                  perm_0C
 perm                    perm_0C
-perm_23C                grain / hr ft^2 in pressure_column_23C of Hg
+perm_23C                grain / hr ft^2 in Hg23C
 perm_twentythree        perm_23C
 
 #
@@ -3211,8 +4856,6 @@ bale                    5 bundles
 # Paper measures
 #
 
-!category paper "Paper Sizes"
-
 # USA paper sizes
 
 lettersize              8.5 inch 11 inch
@@ -3226,7 +4869,7 @@ Dpaper                  22 inch 34 inch
 Epaper                  34 inch 44 inch
 
 # Correspondence envelope sizes.  #10 is the standard business
-# envelope in the USA.
+# envelope in the USA. 
 
 envelope6_25size        3.5 inch 6 inch
 envelope6_75size        3.625 inch 6.5 inch
@@ -3246,7 +4889,7 @@ envelopeA1size          3.625 inch 5.125 inch  # same as 4bar
 envelopeA2size          4.375 inch 5.75 inch
 envelopeA6size          4.75 inch 6.5 inch
 envelopeA7size          5.25 inch 7.25 inch
-envelopeA8size          5.5 inch 8.125 inch
+envelopeA8size          5.5 inch 8.125 inch   
 envelopeA9size          5.75 inch 8.75 inch
 envelopeA10size         6 inch 9.5 inch
 
@@ -3397,13 +5040,9 @@ paperdensity            0.8 g/cm^3        # approximate--paper densities vary!
 papercaliper            in paperdensity
 paperpoint              pointthickness paperdensity
 
-!endcategory
-
 #
 # Printing
 #
-
-!category printing "Printing Units"
 
 fournierpoint           0.1648 inch / 12  # First definition of the printers
                                           # point made by Pierre Fournier who
@@ -3505,37 +5144,29 @@ missal                  48 didotpoint
 kleine_sabon            72 didotpoint
 grobe_sabon             84 didotpoint
 
-!endcategory
-
 #
 # Information theory units.  Note that the name "entropy" is used both
 # to measure information and as a physical quantity.
 #
 
-!category compuing "Computing Units"
+INFORMATION             bit
 
-information             ? bit
-
-#nat                     (1/ln(2)) bits       # Entropy measured base e
-#hartley                 log2(10) bits        # Entropy of a uniformly
-#ban                     hartley              #   distributed random variable
+nat                     (1/ln(2)) bits       # Entropy measured base e
+hartley                 log2(10) bits        # Entropy of a uniformly
+ban                     hartley              #   distributed random variable
                                              #   over 10 symbols.
-#dit                     hartley              # from Decimal digIT
+dit                     hartley              # from Decimal digIT
 
 #
 # Computer
 #
 
-b                       bit
 bps                     bit/sec              # Sometimes the term "baud" is
                                              #   incorrectly used to refer to
                                              #   bits per second.  Baud refers
                                              #   to symbols per second.  Modern
                                              #   modems transmit several bits
                                              #   per symbol.
-Kbps                    kbps                 # Irregular prefixes
-mbps                    Mbps
-gbps                    Gbps
 byte                    8 bit                # Not all machines had 8 bit
 B                       byte                 #   bytes, but these days most of
                                              #   them do.  But beware: for
@@ -3543,7 +5174,6 @@ B                       byte                 #   bytes, but these days most of
                                              #   few extra bits are used so
                                              #   there are actually 10 bits per
                                              #   byte.
-KB                      kB                   # Irregular prefix
 octet                   8 bits               # The octet is always 8 bits
 nybble                  4 bits               # Half of a byte. Sometimes
                                              #   equal to different lengths
@@ -3599,15 +5229,34 @@ dvdspeed                 1385 kB/s   # This is the "1x" speed of a DVD using
                                      # outside of the disc.
                        # See http://www.osta.org/technology/dvdqa/dvdqa4.htm
 
-!endcategory
+FIT         / 1e9 hour # Failures In Time, number of failures per billion hours
+
+#
+# The IP address space is divided into subnets.  The number of hosts
+# in a subnet depends on the length of the subnet prefix.  This is
+# often written as /N where N is the number of bits in the prefix.
+#
+# https://en.wikipedia.org/wiki/Subnetwork
+#
+# These definitions gives the number of hosts for a subnet whose
+# prefix has the specified length in bits.
+#
+
+ipv4subnetsize(prefix_len) units=[1;1]  domain=[0,32] range=[1,4294967296] \
+                         2^(32-prefix_len) ; 32-log2(ipv4subnetsize)
+ipv4classA               ipv4subnetsize(8)
+ipv4classB               ipv4subnetsize(16)
+ipv4classC               ipv4subnetsize(24)
+
+ipv6subnetsize(prefix_len) units=[1;1] domain=[0,128] \
+                         range=[1,340282366920938463463374607431768211456] \
+                         2^(128-prefix_len) ; 128-log2(ipv6subnetsize)
 
 #
 # Musical measures.  Musical intervals expressed as ratios.  Multiply
 # two intervals together to get the sum of the interval.  The function
 # musicalcent can be used to convert ratios to cents.
 #
-
-!category music "Musical Measures"
 
 # Perfect intervals
 
@@ -3629,15 +5278,15 @@ pythagoreancomma        musicalfifth^12 / octave^7
 # Equal tempered definitions
 
 semitone                octave^(1|12)
-#musicalcent(x) units=[1;1] range=(0,) semitone^(x/100) ; \
-#                                      100 log(musicalcent)/log(semitone)
+musicalcent(x) units=[1;1] range=(0,) semitone^(x/100) ; \
+                                      100 log(musicalcent)/log(semitone)
 
 #
 # Musical note lengths.
 #
 
 wholenote               !
-musical_note_length     ? wholenote
+MUSICAL_NOTE_LENGTH     wholenote
 halfnote                1|2 wholenote
 quarternote             1|4 wholenote
 eighthnote              1|8 wholenote
@@ -3656,13 +5305,9 @@ demisemiquaver          thirtysecondnote
 hemidemisemiquaver      sixtyfourthnote
 semidemisemiquaver      hemidemisemiquaver
 
-!endcategory
-
 #
 # yarn and cloth measures
 #
-
-!category cloth "Yarn and Cloth Measures"
 
 # yarn linear density
 
@@ -3706,13 +5351,9 @@ silkmm                  silkmomme        # But it is also defined as
                                          # and neither one seems likely to be
                                          # the true source definition.
 
-!endcategory
-
 #
 # drug dosage
 #
-
-!category dosage "Drug Dosage"
 
 mcg                     microgram        # Frequently used for vitamins
 iudiptheria             62.8 microgram   # IU is for international unit
@@ -3738,7 +5379,6 @@ frenchcathetersize      1|3 mm           # measure used for the outer diameter
                                          # of a catheter
 charriere               frenchcathetersize
 
-!endcategory
 
 #
 # fixup units for times when prefix handling doesn't do the job
@@ -3751,10 +5391,131 @@ microhm                 microohm
 megalerg                megaerg    # 'L' added to make it pronounceable [18].
 
 #
-# Units used for measuring volume of wood
+# Money
+#
+# Note that US$ is the primitive unit so other currencies are
+# generally given in US$.
 #
 
-!category wood "Wood Measures"
+unitedstatesdollar      US$
+usdollar                US$
+$                       dollar
+mark                    germanymark
+#bolivar                 venezuelabolivar       # Not all databases are 
+#venezuelabolivarfuerte  1e-5 bolivar           #    supplying these
+#bolivarfuerte           1e-5 bolivar           # The currency was revalued 
+#oldbolivar              1|1000 bolivarfuerte   # twice
+peseta                  spainpeseta
+rand                    southafricarand
+escudo                  portugalescudo
+guilder                 netherlandsguilder
+hollandguilder          netherlandsguilder
+peso                    mexicopeso
+yen                     japanyen
+lira                    italylira
+rupee                   indiarupee
+drachma                 greecedrachma
+franc                   francefranc
+markka                  finlandmarkka
+britainpound            unitedkingdompound
+greatbritainpound       unitedkingdompound
+unitedkingdompound      ukpound
+poundsterling           britainpound
+yuan                    chinayuan
+
+# Unicode Currency Names
+
+!utf8
+icelandkróna            icelandkrona
+polandzłoty             polandzloty
+tongapa’anga            tongapa'anga
+#venezuelabolívar        venezuelabolivar
+vietnamđồng             vietnamdong
+mongoliatögrög          mongoliatugrik
+sãotomé&príncipedobra   saotome&principedobra
+!endutf8
+
+UKP                     GBP        # Not an ISO code, but looks like one, and
+                                   # sometimes used on usenet.
+
+!include currency.units
+
+# Money on the gold standard, used in the late 19th century and early
+# 20th century.
+
+olddollargold           23.22 grains goldprice  # Used until 1934
+newdollargold           96|7 grains goldprice   # After Jan 31, 1934
+dollargold              newdollargold
+poundgold               113 grains goldprice    # British pound
+
+# Precious metals
+
+goldounce               goldprice troyounce
+silverounce             silverprice troyounce
+platinumounce           platinumprice troyounce
+XAU                     goldounce
+XPT                     platinumounce
+XAG                     silverounce
+
+# Nominal masses of US coins.  Note that dimes, quarters and half dollars
+# have weight proportional to value.  Before 1965 it was $40 / kg.
+
+USpennyweight           2.5 grams         # Since 1982, 48 grains before
+USnickelweight          5 grams
+USdimeweight            US$ 0.10 / (20 US$ / lb)   # Since 1965
+USquarterweight         US$ 0.25 / (20 US$ / lb)   # Since 1965
+UShalfdollarweight      US$ 0.50 / (20 US$ / lb)   # Since 1971
+USdollarweight          8.1 grams         # Weight of Susan B. Anthony and
+                                          #   Sacagawea dollar coins
+
+# British currency
+
+quid                    britainpound        # Slang names
+fiver                   5 quid
+tenner                  10 quid
+monkey                  500 quid
+brgrand                 1000 quid
+bob                     shilling
+
+shilling                1|20 britainpound   # Before decimalisation, there
+oldpence                1|12 shilling       # were 20 shillings to a pound,
+farthing                1|4 oldpence        # each of twelve old pence
+guinea                  21 shilling         # Still used in horse racing
+crown                   5 shilling
+florin                  2 shilling
+groat                   4 oldpence
+tanner                  6 oldpence
+brpenny                 0.01 britainpound
+pence                   brpenny
+tuppence                2 pence
+tuppenny                tuppence
+ha'penny                halfbrpenny
+hapenny                 ha'penny
+oldpenny                oldpence
+oldtuppence             2 oldpence
+oldtuppenny             oldtuppence
+threepence              3 oldpence    # threepence never refers to new money
+threepenny              threepence
+oldthreepence           threepence
+oldthreepenny           threepence
+oldhalfpenny            halfoldpenny
+oldha'penny             oldhalfpenny
+oldhapenny              oldha'penny
+brpony                  25 britainpound
+
+# Canadian currency
+
+loony                   1 canadadollar    # This coin depicts a loon
+toony                   2 canadadollar
+
+# Cryptocurrency
+
+satoshi                 1e-8 bitcoin
+XBT                     bitcoin           # nonstandard code
+
+#
+# Units used for measuring volume of wood
+#
 
 cord                    4*4*8 ft^3   # 4 ft by 4 ft by 8 ft bundle of wood
 facecord                1|2 cord
@@ -3800,20 +5561,17 @@ wholedeal        12 ft 11 in 1.25 in # If it's half as thick as the standard
                                      #   deal it's called a "whole deal"!
 splitdeal         12 ft 11 in 5|8 in # And half again as thick is a split deal.
 
+
 # Used for shellac mixing rate
 
 poundcut            pound / gallon
 lbcut               poundcut
 
-!endcategory
-
 #
 # Gas and Liquid flow units
 #
 
-!category flow_units "Fluid Flow Units"
-
-#FLUID_FLOW              VOLUME / TIME
+FLUID_FLOW              VOLUME / TIME
 
 # Some obvious volumetric gas flow units (cu is short for cubic)
 
@@ -3873,7 +5631,7 @@ sverdrup                1e6 m^3 / sec   # Used to express flow of ocean
 # of gas molecules per unit time, and hence to the mass flow if the
 # molecular mass is known.
 
-#GAS_FLOW                PRESSURE FLUID_FLOW
+GAS_FLOW                PRESSURE FLUID_FLOW
 
 sccm                    atm cc/min     # 's' is for "standard" to indicate
 sccs                    atm cc/sec     # flow at standard pressure
@@ -3882,8 +5640,6 @@ scfm                    atm ft^3/min
 slpm                    atm liter/min
 slph                    atm liter/hour
 lusec                   liter micron Hg / s  # Used in vacuum science
-
-!endcategory
 
 # US Standard Atmosphere (1976)
 # Atmospheric temperature and pressure vs. geometric height above sea level
@@ -3896,52 +5652,50 @@ lusec                   liter micron Hg / s  # Used in vacuum science
 # the definitions of "exponent" and "index."  The functions below assume
 # the following parameters:
 
-!category atmospheric "Atmospheric Measures"
-
 # temperature lapse rate, -dT/dz, in troposphere
 
-lapserate	6.5 K/km	# US Std Atm (1976)
+lapserate       6.5 K/km        # US Std Atm (1976)
 
 # air molecular weight, including constituent mol wt, given
 # in Table 3, p. 3
 
-air_1976      78.084   %  28.0134  g/mol \
-          +   20.9476  %  31.9988  g/mol \
-          + 9340     ppm  39.948   g/mol \
-          +  314     ppm  44.00995 g/mol \
-          +   18.18  ppm  20.183   g/mol \
-          +    5.24  ppm   4.0026  g/mol \
-          +    2     ppm  16.04303 g/mol \
-          +    1.14  ppm  83.80    g/mol \
-          +    0.55  ppm   2.01594 g/mol \
-          +    0.087 ppm 131.30    g/mol
+air_1976        78.084   %    28.0134 \
+              + 20.9476  %    31.9988 \
+              + 9340     ppm  39.948 \
+              +  314     ppm  44.00995 \
+              +   18.18  ppm  20.183 \
+              +    5.24  ppm   4.0026 \
+              +    2     ppm  16.04303 \
+              +    1.14  ppm  83.80 \
+              +    0.55  ppm   2.01594 \
+              +    0.087 ppm 131.30
 
 # universal gas constant
-R_1976		8.31432e3 N m/(kmol K)
+R_1976          8.31432e3 N m/(kmol K)
 
 # polytropic index n
-polyndx_1976	air_1976 gravity/(R_1976 lapserate) - 1
+polyndx_1976    air_1976 (kg/kmol) gravity/(R_1976 lapserate) - 1
 
 # If desired, redefine using current values for air mol wt and R
 
-polyndx		polyndx_1976
-# polyndx	air (kg/kmol) gravity/(R lapserate) - 1
+polyndx         polyndx_1976
+# polyndx       air (kg/kmol) gravity/(R lapserate) - 1
 
 # for comparison with various references
 
-polyexpnt	(polyndx + 1) / polyndx
+polyexpnt       (polyndx + 1) / polyndx
 
 # The model assumes the following reference values:
 # sea-level temperature and pressure
 
-stdatmT0	288.15 K
-stdatmP0	atm
+stdatmT0        288.15 K
+stdatmP0        atm
 
 # "effective radius" for relation of geometric to geopotential height,
 # at a latitude at which g = 9.80665 m/s (approximately 45.543 deg); no
 # relation to actual radius
 
-earthradUSAtm	6356766 m
+earthradUSAtm   6356766 m
 
 # Temperature vs. geopotential height h
 # Assumes 15 degC at sea level
@@ -3949,12 +5703,12 @@ earthradUSAtm	6356766 m
 # Lower limits of domain and upper limits of range are those of the
 # tables in US Standard Atmosphere (NASA 1976)
 
-#stdatmTH(h) units=[m;K] domain=[-5000,11e3] range=[217,321] \
-#    stdatmT0+(-lapserate h) ; (stdatmT0+(-stdatmTH))/lapserate
+stdatmTH(h) units=[m;K] domain=[-5000,11e3] range=[217,321] \
+    stdatmT0+(-lapserate h) ; (stdatmT0+(-stdatmTH))/lapserate
 
 # Temperature vs. geometric height z; based on approx 45 deg latitude
-#stdatmT(z) units=[m;K] domain=[-5000,11e3] range=[217,321] \
-#    stdatmTH(geop_ht(z)) ; ~geop_ht(~stdatmTH(stdatmT))
+stdatmT(z) units=[m;K] domain=[-5000,11e3] range=[217,321] \
+    stdatmTH(geop_ht(z)) ; ~geop_ht(~stdatmTH(stdatmT))
 
 # Pressure vs. geopotential height h
 # Assumes 15 degC and 101325 Pa at sea level
@@ -3962,22 +5716,22 @@ earthradUSAtm	6356766 m
 # Lower limits of domain and upper limits of range are those of the
 # tables in US Standard Atmosphere (NASA 1976)
 
-#stdatmPH(h) units=[m;Pa] domain=[-5000,11e3] range=[22877,177764] \
-#    atm (1 - (lapserate/stdatmT0) h)^(polyndx + 1) ; \
-#    (stdatmT0/lapserate) (1+(-(stdatmPH/stdatmP0)^(1/(polyndx + 1))))
+stdatmPH(h) units=[m;Pa] domain=[-5000,11e3] range=[22877,177764] \
+    atm (1 - (lapserate/stdatmT0) h)^(polyndx + 1) ; \
+    (stdatmT0/lapserate) (1+(-(stdatmPH/stdatmP0)^(1/(polyndx + 1))))
 
 # Pressure vs. geometric height z; based on approx 45 deg latitude
-#stdatmP(z) units=[m;Pa] domain=[-5000,11e3] range=[22877,177764] \
-#   stdatmPH(geop_ht(z)); ~geop_ht(~stdatmPH(stdatmP))
+stdatmP(z) units=[m;Pa] domain=[-5000,11e3] range=[22877,177764] \
+   stdatmPH(geop_ht(z)); ~geop_ht(~stdatmPH(stdatmP))
 
 # Geopotential height from geometric height
 # Based on approx 45 deg latitude
 # Lower limits of domain and range are somewhat arbitrary; they
 # correspond to the limits in the US Std Atm tables
 
-#geop_ht(z) units=[m;m] domain=[-5000,) range=[-5004,) \
-#    (earthradUSAtm z) / (earthradUSAtm + z) ; \
-#    (earthradUSAtm geop_ht) / (earthradUSAtm + (-geop_ht))
+geop_ht(z) units=[m;m] domain=[-5000,) range=[-5004,) \
+    (earthradUSAtm z) / (earthradUSAtm + z) ; \
+    (earthradUSAtm geop_ht) / (earthradUSAtm + (-geop_ht))
 
 # The standard value for the sea-level acceleration due to gravity is
 # 9.80665 m/s^2, but the actual value varies with latitude (Harrison 1949)
@@ -3989,15 +5743,15 @@ earthradUSAtm	6356766 m
 # There is no inverse function; the standard value applies at a latitude
 # of about 45.543 deg
 
-#g_phi(lat) units=[deg;m/s2] domain=[0,90] noerror  \
-#    980.6160e-2 (1+(-0.0026373) cos(2 lat)+0.0000059 cos(2 lat)^2) m/s2
+g_phi(lat) units=[deg;m/s2] domain=[0,90] noerror  \
+    980.6160e-2 (1+(-0.0026373) cos(2 lat)+0.0000059 cos(2 lat)^2) m/s2
 
 # effective Earth radius for relation of geometric height to
 # geopotential height, as function of latitude (Harrison 1949)
 
-#earthradius_eff(lat) units=[deg;m] domain=[0,90] noerror \
-#    m 2 9.780356 (1+0.0052885 sin(lat)^2+(-0.0000059) sin(2 lat)^2) / \
-#    (3.085462e-6 + 2.27e-9 cos(2 lat) + (-2e-12) cos(4 lat))
+earthradius_eff(lat) units=[deg;m] domain=[0,90] noerror \
+    m 2 9.780356 (1+0.0052885 sin(lat)^2+(-0.0000059) sin(2 lat)^2) / \
+    (3.085462e-6 + 2.27e-9 cos(2 lat) + (-2e-12) cos(4 lat))
 
 # References
 # Harrison, L.P. 1949.  Relation Between Geopotential and Geometric
@@ -4024,15 +5778,20 @@ earthradUSAtm	6356766 m
 # Patm appropriately, and adjust the lower domain limit on the gaugepressure
 # definition.
 
-#Patm	atm
+Patm    atm
 
-#gaugepressure(x) units=[Pa;Pa] domain=[-101325,) range=[0,) \
-#                x + Patm ; gaugepressure+(-Patm)
+gaugepressure(x) units=[Pa;Pa] domain=[-101325,) range=[0,) \
+                x + Patm ; gaugepressure+(-Patm)
 
-#psig(x) units=[1;Pa] domain=[-14.6959487755135,) range=[0,) \
-#    gaugepressure(x psi) ; ~gaugepressure(psig) / psi
+psig(x) units=[1;Pa] domain=[-14.6959487755135,) range=[0,) \
+    gaugepressure(x psi) ; ~gaugepressure(psig) / psi
 
-!endcategory
+
+# Pressure for underwater diving
+
+seawater             0.1 bar / meter
+msw                  meter seawater
+fsw                  foot seawater
 
 #
 # Wire Gauge
@@ -4049,16 +5808,12 @@ earthradUSAtm	6356766 m
 # Alternatively, you can use the following units:
 #
 
-!category gauges "Wire Gauges"
-
 g00                      (-1)
 g000                     (-2)
 g0000                    (-3)
 g00000                   (-4)
 g000000                  (-5)
 g0000000                 (-6)
-
-!endcategory
 
 # American Wire Gauge (AWG) or Brown & Sharpe Gauge appears to be the most
 # important gauge. ASTM B-258 specifies that this gauge is based on geometric
@@ -4076,30 +5831,30 @@ g0000000                 (-6)
 # measure the thickness of sheets of aluminum, copper, and most metals other
 # than steel, iron and zinc.
 
-#wiregauge(g) units=[1;m] range=(0,) \
-#             1|200 92^((36+(-g))/39) in; 36+(-39)ln(200 wiregauge/in)/ln(92)
-#awg()        wiregauge
+wiregauge(g) units=[1;m] range=(0,) \
+             1|200 92^((36+(-g))/39) in; 36+(-39)ln(200 wiregauge/in)/ln(92)
+awg()        wiregauge
 
 # Next we have the SWG, the Imperial or British Standard Wire Gauge.  This one
 # is piecewise linear.  It was used for aluminum sheets.
 
-#brwiregauge[in]  \
-#       -6 0.5    \
-#       -5 0.464  \
-#       -3 0.4    \
-#       -2 0.372  \
-#        3 0.252  \
-#        6 0.192  \
-#       10 0.128  \
-#       14 0.08   \
-#       19 0.04   \
-#       23 0.024  \
-#       26 0.018  \
-#       28 0.0148 \
-#       30 0.0124 \
-#       39 0.0052 \
-#       49 0.0012 \
-#       50 0.001
+brwiregauge[in]  \
+       -6 0.5    \
+       -5 0.464  \
+       -3 0.4    \
+       -2 0.372  \
+        3 0.252  \
+        6 0.192  \
+       10 0.128  \
+       14 0.08   \
+       19 0.04   \
+       23 0.024  \
+       26 0.018  \
+       28 0.0148 \
+       30 0.0124 \
+       39 0.0052 \
+       49 0.0012 \
+       50 0.001
 
 # The following is from the Appendix to ASTM B 258
 #
@@ -4122,54 +5877,156 @@ g0000000                 (-6)
 
 # Old plate gauge for iron
 
-#plategauge[(oz/ft^2)/(480*lb/ft^3)] \
-#      -5 300   \
-#       1 180   \
-#      14  50   \
-#      16  40   \
-#      17  36   \
-#      20  24   \
-#      26  12   \
-#      31   7   \
-#      36   4.5 \
-#      38   4
+plategauge[(oz/ft^2)/(480*lb/ft^3)] \
+      -5 300   \
+       1 180   \
+      14  50   \
+      16  40   \
+      17  36   \
+      20  24   \
+      26  12   \
+      31   7   \
+      36   4.5 \
+      38   4
 
 # Manufacturers Standard Gage
 
-#stdgauge[(oz/ft^2)/(501.84*lb/ft^3)] \
-#      -5 300   \
-#       1 180   \
-#      14  50   \
-#      16  40   \
-#      17  36   \
-#      20  24   \
-#      26  12   \
-#      31   7   \
-#      36   4.5 \
-#      38   4
+stdgauge[(oz/ft^2)/(501.84*lb/ft^3)] \
+      -5 300   \
+       1 180   \
+      14  50   \
+      16  40   \
+      17  36   \
+      20  24   \
+      26  12   \
+      31   7   \
+      36   4.5 \
+      38   4
 
 # A special gauge is used for zinc sheet metal.  Notice that larger gauges
 # indicate thicker sheets.
 
-#zincgauge[in]    \
-#        1 0.002  \
-#       10 0.02   \
-#       15 0.04   \
-#       19 0.06   \
-#       23 0.1    \
-#       24 0.125  \
-#       27 0.5    \
-#       28 1
+zincgauge[in]    \
+        1 0.002  \
+       10 0.02   \
+       15 0.04   \
+       19 0.06   \
+       23 0.1    \
+       24 0.125  \
+       27 0.5    \
+       28 1
+
+#
+# Imperial drill bit sizes are reported in inches or in a numerical or
+# letter gauge.
+#
+
+drillgauge[in] \
+       1  0.2280 \
+       2  0.2210 \
+       3  0.2130 \
+       4  0.2090 \
+       5  0.2055 \
+       6  0.2040 \
+       7  0.2010 \
+       8  0.1990 \
+       9  0.1960 \
+      10  0.1935 \
+      11  0.1910 \
+      12  0.1890 \
+      13  0.1850 \
+      14  0.1820 \
+      15  0.1800 \
+      16  0.1770 \
+      17  0.1730 \
+      18  0.1695 \
+      19  0.1660 \
+      20  0.1610 \
+      22  0.1570 \
+      23  0.1540 \
+      24  0.1520 \
+      25  0.1495 \
+      26  0.1470 \
+      27  0.1440 \
+      28  0.1405 \
+      29  0.1360 \
+      30  0.1285 \
+      31  0.1200 \
+      32  0.1160 \
+      33  0.1130 \
+      34  0.1110 \
+      35  0.1100 \
+      36  0.1065 \
+      38  0.1015 \
+      39  0.0995 \
+      40  0.0980 \
+      41  0.0960 \
+      42  0.0935 \
+      43  0.0890 \
+      44  0.0860 \
+      45  0.0820 \
+      46  0.0810 \
+      48  0.0760 \
+      51  0.0670 \
+      52  0.0635 \
+      53  0.0595 \
+      54  0.0550 \
+      55  0.0520 \
+      56  0.0465 \
+      57  0.0430 \
+      65  0.0350 \
+      66  0.0330 \
+      68  0.0310 \
+      69  0.0292 \
+      70  0.0280 \
+      71  0.0260 \
+      73  0.0240 \
+      74  0.0225 \
+      75  0.0210 \
+      76  0.0200 \
+      78  0.0160 \
+      79  0.0145 \
+      80  0.0135 \
+      88  0.0095 \
+      104 0.0031 
+
+drillA    0.234 in
+drillB    0.238 in
+drillC    0.242 in
+drillD    0.246 in
+drillE    0.250 in
+drillF    0.257 in
+drillG    0.261 in
+drillH    0.266 in
+drillI    0.272 in
+drillJ    0.277 in
+drillK    0.281 in
+drillL    0.290 in
+drillM    0.295 in
+drillN    0.302 in
+drillO    0.316 in
+drillP    0.323 in
+drillQ    0.332 in
+drillR    0.339 in
+drillS    0.348 in
+drillT    0.358 in
+drillU    0.368 in
+drillV    0.377 in
+drillW    0.386 in
+drillX    0.397 in
+drillY    0.404 in
+drillZ    0.413 in
 
 #
 # Screw sizes
 #
-# In the USA, screw diameters are reported using a gauge number.
-# Metric screws are reported as Mxx where xx is the diameter in mm.
+# In the USA, screw diameters for both wood screws and machine screws
+# are reported using a gauge number.  Metric machine screws are
+# reported as Mxx where xx is the diameter in mm.
 #
 
-#screwgauge(g) units=[1;m] range=[0,) \
-#              (.06 + .013 g) in ; (screwgauge/in + (-.06)) / .013
+screwgauge(g) units=[1;m] range=[0,) \
+              (.06 + .013 g) in ; (screwgauge/in + (-.06)) / .013
 
 #
 # Abrasive grit size
@@ -4216,79 +6073,79 @@ g0000000                 (-6)
 # grits so that the particles are more uniform in size and hence give
 # a better finish.
 
-#grit_P[micron] \
-#        12 1815 \
-#        16 1324 \
-#        20 1000 \
-#        24 764 \
-#        30 642 \
-#        36 538 \
-#        40 425 \
-#        50 336 \
-#        60 269 \
-#        80 201 \
-#        100 162 \
-#        120 125 \
-#        150 100 \
-#        180 82 \
-#        220 68 \
-#        240 58.5 \
-#        280 52.2 \
-#        320 46.2 \
-#        360 40.5 \
-#        400 35 \
-#        500 30.2 \
-#        600 25.8 \
-#        800 21.8 \
-#        1000 18.3 \
-#        1200 15.3 \
-#        1500 12.6 \
-#        2000 10.3 \
-#        2500 8.4
+grit_P[micron] \
+        12 1815 \
+        16 1324 \
+        20 1000 \
+        24 764 \
+        30 642 \
+        36 538 \
+        40 425 \
+        50 336 \
+        60 269 \
+        80 201 \
+        100 162 \
+        120 125 \
+        150 100 \
+        180 82 \
+        220 68 \
+        240 58.5 \
+        280 52.2 \
+        320 46.2 \
+        360 40.5 \
+        400 35 \
+        500 30.2 \
+        600 25.8 \
+        800 21.8 \
+        1000 18.3 \
+        1200 15.3 \
+        1500 12.6 \
+        2000 10.3 \
+        2500 8.4
 
 # The F grit is the European standard for bonded abrasives such as
 # grinding wheels
 
-#grit_F[micron] \
-#        4 4890 \
-#        5 4125 \
-#        6 3460 \
-#        7 2900 \
-#        8 2460 \
-#        10 2085 \
-#        12 1765 \
-#        14 1470 \
-#        16 1230 \
-#        20 1040 \
-#        22 885 \
-#        24 745 \
-#        30 625 \
-#        36 525 \
-#        40 438 \
-#        46 370 \
-#        54 310 \
-#        60 260 \
-#        70 218 \
-#        80 185 \
-#        90 154 \
-#        100 129 \
-#        120 109 \
-#        150 82 \
-#        180 69 \
-#        220 58 \
-#        230 53 \
-#        240 44.5 \
-#        280 36.5 \
-#        320 29.2 \
-#        360 22.8 \
-#        400 17.3 \
-#        500 12.8 \
-#        600 9.3 \
-#        800 6.5 \
-#        1000 4.5 \
-#        1200 3 \
-#        1500 2.0 \
-#        2000 1.2
+grit_F[micron] \
+        4 4890 \
+        5 4125 \
+        6 3460 \
+        7 2900 \
+        8 2460 \
+        10 2085 \
+        12 1765 \
+        14 1470 \
+        16 1230 \
+        20 1040 \
+        22 885 \
+        24 745 \
+        30 625 \
+        36 525 \
+        40 438 \
+        46 370 \
+        54 310 \
+        60 260 \
+        70 218 \
+        80 185 \
+        90 154 \
+        100 129 \
+        120 109 \
+        150 82 \
+        180 69 \
+        220 58 \
+        230 53 \
+        240 44.5 \
+        280 36.5 \
+        320 29.2 \
+        360 22.8 \
+        400 17.3 \
+        500 12.8 \
+        600 9.3 \
+        800 6.5 \
+        1000 4.5 \
+        1200 3 \
+        1500 2.0 \
+        2000 1.2
 
 # According to the UAMA web page, the ANSI bonded and ANSI coated standards
 # are identical to FEPA F in the macrogrit range (under 240 grit), so these
@@ -4296,45 +6153,45 @@ g0000000                 (-6)
 # from the UAMA web site and represent the average of the "d50" range
 # endpoints listed there.
 
-# ansibonded[micron] \
-#     4 4890 \
-#     5 4125 \
-#     6 3460 \
-#     7 2900 \
-#     8 2460 \
-#     10 2085 \
-#     12 1765 \
-#     14 1470 \
-#     16 1230 \
-#     20 1040 \
-#     22 885 \
-#     24 745 \
-#     30 625 \
-#     36 525 \
-#     40 438 \
-#     46 370 \
-#     54 310 \
-#     60 260 \
-#     70 218 \
-#     80 185 \
-#     90 154 \
-#     100 129 \
-#     120 109 \
-#     150 82 \
-#     180 69 \
-#     220 58 \
-#     240 50 \
-#     280 39.5 \
-#     320 29.5 \
-#     360 23 \
-#     400 18.25 \
-#     500 13.9 \
-#     600 10.55 \
-#     800 7.65 \
-#     1000 5.8 \
-#     1200 3.8
+ansibonded[micron] \
+    4 4890 \
+    5 4125 \
+    6 3460 \
+    7 2900 \
+    8 2460 \
+    10 2085 \
+    12 1765 \
+    14 1470 \
+    16 1230 \
+    20 1040 \
+    22 885 \
+    24 745 \
+    30 625 \
+    36 525 \
+    40 438 \
+    46 370 \
+    54 310 \
+    60 260 \
+    70 218 \
+    80 185 \
+    90 154 \
+    100 129 \
+    120 109 \
+    150 82 \
+    180 69 \
+    220 58 \
+    240 50 \
+    280 39.5 \
+    320 29.5 \
+    360 23 \
+    400 18.25 \
+    500 13.9 \
+    600 10.55 \
+    800 7.65 \
+    1000 5.8 \
+    1200 3.8
 
-# grit_ansibonded() ansibonded
+grit_ansibonded() ansibonded
 
 # Like the bonded grit, the coated macrogrits below 240 are taken from the
 # FEPA F table.  Data above this is from the UAMA site.  Note that the coated
@@ -4347,75 +6204,75 @@ g0000000                 (-6)
 # Because of this non-monotonicity from 600 grit to 800 grit this definition
 # produces a warning about the lack of a unique inverse.
 
-# ansicoated[micron] noerror \
-#     4 4890 \
-#     5 4125 \
-#     6 3460 \
-#     7 2900 \
-#     8 2460 \
-#     10 2085 \
-#     12 1765 \
-#     14 1470 \
-#     16 1230 \
-#     20 1040 \
-#     22 885 \
-#     24 745 \
-#     30 625 \
-#     36 525 \
-#     40 438 \
-#     46 370 \
-#     54 310 \
-#     60 260 \
-#     70 218 \
-#     80 185 \
-#     90 154 \
-#     100 129 \
-#     120 109 \
-#     150 82 \
-#     180 69 \
-#     220 58 \
-#     240 50 \
-#     280 39.5 \
-#     320 29.5 \
-#     360 23 \
-#     400 18.25 \
-#     500 13.9 \
-#     600 10.55 \
-#     800 11.5 \
-#     1000 9.5 \
-#     2000 7.2 \
-#     2500 5.5 \
-#     3000 4 \
-#     4000 3 \
-#     6000 2 \
-#     8000 1.2
+ansicoated[micron] noerror \
+    4 4890 \
+    5 4125 \
+    6 3460 \
+    7 2900 \
+    8 2460 \
+    10 2085 \
+    12 1765 \
+    14 1470 \
+    16 1230 \
+    20 1040 \
+    22 885 \
+    24 745 \
+    30 625 \
+    36 525 \
+    40 438 \
+    46 370 \
+    54 310 \
+    60 260 \
+    70 218 \
+    80 185 \
+    90 154 \
+    100 129 \
+    120 109 \
+    150 82 \
+    180 69 \
+    220 58 \
+    240 50 \
+    280 39.5 \
+    320 29.5 \
+    360 23 \
+    400 18.25 \
+    500 13.9 \
+    600 10.55 \
+    800 11.5 \
+    1000 9.5 \
+    2000 7.2 \
+    2500 5.5 \
+    3000 4 \
+    4000 3 \
+    6000 2 \
+    8000 1.2
 
-# grit_ansicoated()  ansicoated
+grit_ansicoated()  ansicoated
 
 
 #
 # Is this correct?  This is the JIS Japanese standard used on waterstones
 #
-# jisgrit[micron] \
-#      150 75 \
-#      180 63 \
-#      220 53 \
-#      280 48 \
-#      320 40 \
-#      360 35 \
-#      400 30 \
-#      600 20 \
-#      700 17 \
-#      800 14 \
-#      1000 11.5 \
-#      1200 9.5 \
-#      1500 8 \
-#      2000 6.7 \
-#      2500 5.5 \
-#      3000 4 \
-#      4000 3 \
-#      6000 2 \
-#      8000 1.2
+jisgrit[micron] \
+     150 75 \
+     180 63 \
+     220 53 \
+     280 48 \
+     320 40 \
+     360 35 \
+     400 30 \
+     600 20 \
+     700 17 \
+     800 14 \
+     1000 11.5 \
+     1200 9.5 \
+     1500 8 \
+     2000 6.7 \
+     2500 5.5 \
+     3000 4 \
+     4000 3 \
+     6000 2 \
+     8000 1.2
 
 # The "Finishing Scale" marked with an A (e.g. A75).  This information
 # is from the web page of the sand paper manufacturer Klingspor
@@ -4423,26 +6280,24 @@ g0000000                 (-6)
 #
 # I have no information about what this scale is used for.
 
-# grit_A[micron]\
-#      16 15.3 \
-#      25 21.8 \
-#      30 23.6 \
-#      35 25.75 \
-#      45 35 \
-#      60 46.2 \
-#      65 53.5 \
-#      75 58.5 \
-#      90 65 \
-#      110 78 \
-#      130 93 \
-#      160 127 \
-#      200 156
+grit_A[micron]\
+     16 15.3 \
+     25 21.8 \
+     30 23.6 \
+     35 25.75 \
+     45 35 \
+     60 46.2 \
+     65 53.5 \
+     75 58.5 \
+     90 65 \
+     110 78 \
+     130 93 \
+     160 127 \
+     200 156
 #
 # Grits for DMT brand diamond sharpening stones from
 # http://dmtsharp.com/products/colorcode.htm
 #
-
-!category grits "Grit Sizes"
 
 dmtxxcoarse  120 micron    # 120 mesh
 dmtsilver    dmtxxcoarse
@@ -4488,7 +6343,172 @@ hardblackarkansas        6 micron
 hardwhitearkansas        11 micron
 washita                  35 micron
 
-!endcategory
+#
+# Mesh systems for measuring particle sizes by sifting through a wire
+# mesh or sieve
+#
+
+# The Tyler system and US Sieve system are based on four steps for
+# each factor of 2 change in the size, so each size is 2^1|4 different
+# from the adjacent sizes.  Unfortunately, the mesh numbers are
+# arbitrary, so the sizes cannot be expressed with a functional form.
+# Various references round the values differently.  The mesh numbers
+# are supposed to correspond to the number of holes per inch, but this
+# correspondence is only approximate because it doesn't include the
+# wire size of the mesh.
+
+# The Tyler Mesh system was apparently introduced by the WS Tyler
+# company, but it appears that they no longer use it.  They follow the
+# ASTM E11 standard.
+
+meshtyler[micron] \
+          2.5 8000 \
+          3   6727 \
+          3.5 5657 \
+          4   4757 \
+          5   4000 \
+          6   3364 \
+          7   2828 \
+          8   2378 \
+          9   2000 \
+         10   1682 \
+         12   1414 \
+         14   1189 \
+         16   1000 \
+         20    841 \
+         24    707 \
+         28    595 \
+         32    500 \
+         35    420 \
+         42    354 \
+         48    297 \
+         60    250 \
+         65    210 \
+         80    177 \
+        100    149 \
+        115    125 \
+        150    105 \
+        170     88 \
+        200     74 \
+        250     63 \
+        270     53 \
+        325     44 \
+        400     37 
+
+# US Sieve size, ASTM E11
+#
+# The WS Tyler company prints the list from ASTM E11 in their catalog, 
+# http://wstyler.com/wp-content/uploads/2015/11/Product-Catalog-2.pdf
+
+sieve[micron] \
+          3.5   5600 \
+          4     4750 \
+          5     4000 \
+          6     3350 \
+          7     2800 \
+          8     2360 \
+         10     2000 \
+         12     1700 \
+         14     1400 \
+         16     1180 \
+         18     1000 \
+         20      850 \
+         25      710 \
+         30      600 \
+         35      500 \
+         40      425 \
+         45      355 \
+         50      300 \
+         60      250 \
+         70      212 \
+         80      180 \
+        100      150 \
+        120      125 \
+        140      106 \
+        170       90 \
+        200       75 \
+        230       63 \
+        270       53 \
+        325       45 \
+        400       38 \
+        450       32 \
+        500       25 \
+        625       20   # These last two values are not in the standard series
+                       # but were included in the ASTM standard because they
+meshUS()  sieve        # were in common usage.                               
+
+# British Mesh size, BS 410: 1986
+# This system appears to correspond to the Tyler and US system, but
+# with different mesh numbers.
+#
+# http://www.panadyne.com/technical/panadyne_international_sieve_chart.pdf
+# 
+
+meshbritish[micron] \
+          3    5657 \
+          3.5  4757 \
+          4    4000 \
+          5    3364 \
+          6    2828 \
+          7    2378 \
+          8    2000 \
+         10    1682 \
+         12    1414 \
+         14    1189 \
+         16    1000 \
+         18     841 \
+         22     707 \
+         25     595 \
+         30     500 \
+         36     420 \
+         44     354 \
+         52     297 \
+         60     250 \
+         72     210 \
+         85     177 \
+        100     149 \
+        120     125 \
+        150     105 \
+        170      88 \
+        200      74 \
+        240      63 \
+        300      53 \
+        350      44 \
+        400      37  
+
+# French system, AFNOR NFX11-501: 1970
+# The system appears to be based on size doubling every 3 mesh
+# numbers, though the values have been agressively rounded.
+# It's not clear if the unrounded values would be considered
+# incorrect, so this is given as a table rather than a function.
+# Functional form:
+#    meshtamis(mesh) units=[1;m] 5000 2^(1|3 (mesh-38)) micron
+#
+# http://www.panadyne.com/technical/panadyne_international_sieve_chart.pdf
+
+meshtamis[micron] \
+        17   40 \
+        18   50 \
+        19   63 \
+        20   80 \
+        21  100 \
+        22  125 \
+        23  160 \
+        24  200 \
+        25  250 \
+        26  315 \
+        27  400 \
+        28  500 \
+        29  630 \
+        30  800 \
+        31 1000 \
+        32 1250 \
+        33 1600 \
+        34 2000 \
+        35 2500 \
+        36 3150 \
+        37 4000 \
+        38 5000 
 
 #
 # Ring size. All ring sizes are given as the circumference of the ring.
@@ -4506,8 +6526,8 @@ washita                  35 micron
 # circumference, but that source doesn't have an explanation for the modern
 # system which is somewhat different.
 
-#ringsize(n) units=[1;in] domain=[2,) range=[1.6252,) \
-#            (1.4216+.1018 n) in ; (ringsize/in + (-1.4216))/.1018
+ringsize(n) units=[1;in] domain=[2,) range=[1.6252,) \
+            (1.4216+.1018 n) in ; (ringsize/in + (-1.4216))/.1018
 
 # Old practice in the UK measured rings using the "Wheatsheaf gauge" with sizes
 # specified alphabetically and based on the ring inside diameter in steps of
@@ -4516,8 +6536,6 @@ washita                  35 micron
 # the preceding size.  The baseline is size C which is 40 mm circumference.
 # The new sizes are close to the old ones.  Sometimes it's necessary to go
 # beyond size Z to Z+1, Z+2, etc.
-
-!category ring_sizes "Ring Sizes"
 
 sizeAring               37.50 mm
 sizeBring               38.75 mm
@@ -4546,18 +6564,16 @@ sizeXring               66.25 mm
 sizeYring               67.50 mm
 sizeZring               68.75 mm
 
-!endcategory
-
 # Japanese sizes start with size 1 at a 13mm inside diameter and each size is
 # 1|3 mm larger in diameter than the previous one.  They are multiplied by pi
 # to give circumference.
 
-#jpringsize(n)  units=[1;mm] domain=[1,) range=[0.040840704,) \
-#               (38|3 + n/3) pi mm ; 3 jpringsize/ pi mm + (-38)
+jpringsize(n)  units=[1;mm] domain=[1,) range=[0.040840704,) \
+               (38|3 + n/3) pi mm ; 3 jpringsize/ pi mm + (-38)
 
 # The European ring sizes are the length of the circumference in mm minus 40.
 
-#euringsize(n)  units=[1;mm] (n+40) mm ; euringsize/mm + (-40)
+euringsize(n)  units=[1;mm] (n+40) mm ; euringsize/mm + (-40)
 
 #
 # Abbreviations
@@ -4566,12 +6582,12 @@ sizeZring               68.75 mm
 mph                     mile/hr
 mpg                     mile/gal
 kph                     km/hr
-kmh                     km/hr
 fL                      footlambert
 fpm                     ft/min
 fps                     ft/s
 rpm                     rev/min
 rps                     rev/sec
+mi                      mile
 smi                     mile
 nmi                     nauticalmile
 mbh                     1e3 btu/hour
@@ -4586,7 +6602,7 @@ hph                     hp hour
 plf                     lb / foot    # pounds per linear foot
 
 #
-# Compatibility units with unix version
+# Compatibility units with Unix version
 #
 
 pa                      Pa
@@ -4610,8 +6626,6 @@ coul                    C
 # Radioactivity units
 #
 
-!category radioactivity "Radioactivity Units"
-
 becquerel               /s           # Activity of radioactive source
 Bq                      becquerel    #
 curie                   3.7e10 Bq    # Defined in 1910 as the radioactivity
@@ -4619,7 +6633,7 @@ Ci                      curie        # emitted by the amount of radon that is
                                      # in equilibrium with 1 gram of radium.
 rutherford              1e6 Bq       #
 
-radiation_dose          gray
+RADIATION_DOSE          gray
 gray                    J/kg         # Absorbed dose of radiation
 Gy                      gray         #
 rad                     1e-2 Gy      # From Radiation Absorbed Dose
@@ -4655,7 +6669,8 @@ rem                     1e-2 Sv      #   keV X-rays.  Different types of
                                      #
                                      # rem stands for Roentgen Equivalent
                                      # Mammal
-
+banana_dose           0.1e-6 sievert # Informal measure of the dose due to 
+                                     #   eating one average sized banana
 roentgen              2.58e-4 C / kg # Ionizing radiation that produces
                                      #   1 statcoulomb of charge in 1 cc of
                                      #   dry air at stp.
@@ -4668,7 +6683,288 @@ sievertunit             8.38 rontgen # Unit of gamma ray dose delivered in one
 eman                    1e-7 Ci/m^3  # radioactive concentration
 mache                   3.7e-7 Ci/m^3
 
-!endcategory
+#
+# Atomic weights.  The atomic weight of an element is the ratio of the mass of
+# a mole of the element to 1|12 of a mole of Carbon 12.  The Standard Atomic
+# Weights apply to the elements as they occur naturally on earth.  Elements
+# which do not occur naturally or which occur with wide isotopic variability do
+# not have Standard Atomic Weights.  For these elements, the atomic weight is
+# based on the longest lived isotope, as marked in the comments.  In some
+# cases, the comment for these entries also gives a number which is an atomic
+# weight for a different isotope that may be of more interest than the longest
+# lived isotope.
+#
+
+actinium                227.0278
+aluminum                26.981539
+americium               243.0614     # Longest lived. 241.06
+antimony                121.760
+argon                   39.948
+arsenic                 74.92159
+astatine                209.9871     # Longest lived
+barium                  137.327
+berkelium               247.0703     # Longest lived. 249.08
+beryllium               9.012182
+bismuth                 208.98037
+boron                   10.811
+bromine                 79.904
+cadmium                 112.411
+calcium                 40.078
+californium             251.0796     # Longest lived.  252.08
+carbon                  12.011
+cerium                  140.115
+cesium                  132.90543
+chlorine                35.4527
+chromium                51.9961
+cobalt                  58.93320
+copper                  63.546
+curium                  247.0703
+deuterium               2.0141017778
+dysprosium              162.50
+einsteinium             252.083      # Longest lived
+erbium                  167.26
+europium                151.965
+fermium                 257.0951     # Longest lived
+fluorine                18.9984032
+francium                223.0197     # Longest lived
+gadolinium              157.25
+gallium                 69.723
+germanium               72.61
+gold                    196.96654
+hafnium                 178.49
+helium                  4.002602
+holmium                 164.93032
+hydrogen                1.00794
+indium                  114.818
+iodine                  126.90447
+iridium                 192.217
+iron                    55.845
+krypton                 83.80
+lanthanum               138.9055
+lawrencium              262.11       # Longest lived
+lead                    207.2
+lithium                 6.941
+lutetium                174.967
+magnesium               24.3050
+manganese               54.93805
+mendelevium             258.10       # Longest lived
+mercury                 200.59
+molybdenum              95.94
+neodymium               144.24
+neon                    20.1797
+neptunium               237.0482
+nickel                  58.6934
+niobium                 92.90638
+nitrogen                14.00674
+nobelium                259.1009     # Longest lived
+osmium                  190.23
+oxygen                  15.9994
+palladium               106.42
+phosphorus              30.973762
+platinum                195.08
+plutonium               244.0642     # Longest lived.  239.05
+polonium                208.9824     # Longest lived.  209.98
+potassium               39.0983
+praseodymium            140.90765
+promethium              144.9127     # Longest lived.  146.92
+protactinium            231.03588
+radium                  226.0254
+radon                   222.0176     # Longest lived
+rhenium                 186.207
+rhodium                 102.90550
+rubidium                85.4678
+ruthenium               101.07
+samarium                150.36
+scandium                44.955910
+selenium                78.96
+silicon                 28.0855
+silver                  107.8682
+sodium                  22.989768
+strontium               87.62
+sulfur                  32.066
+tantalum                180.9479
+technetium              97.9072      # Longest lived.  98.906
+tellurium               127.60
+terbium                 158.92534
+thallium                204.3833
+thorium                 232.0381
+thullium                168.93421
+tin                     118.710
+titanium                47.867
+tungsten                183.84
+uranium                 238.0289
+vanadium                50.9415
+xenon                   131.29
+ytterbium               173.04
+yttrium                 88.90585
+zinc                    65.39
+zirconium               91.224
+
+# Average molecular weight of air
+#
+# The atmospheric composition listed is from NASA Earth Fact Sheet (accessed
+# 28 August 2015)
+# http://nssdc.gsfc.nasa.gov/planetary/factsheet/earthfact.html
+# Numbers do not add up to exactly 100% due to roundoff and uncertainty Water
+# is highly variable, typically makes up about 1%
+
+air            78.08% nitrogen 2 \
+              + 20.95% oxygen 2 \
+              + 9340 ppm argon \
+              +  400 ppm (carbon + oxygen 2) \
+              +   18.18 ppm neon \
+              +    5.24 ppm helium \
+              +    1.7  ppm (carbon + 4 hydrogen) \
+              +    1.14 ppm krypton \
+              +    0.55 ppm hydrogen 2
+
+
+# Density of the elements
+#
+# Note some elements occur in multiple forms (allotropes) with different
+# densities, and they are accordingly listed multiple times.  
+
+# Density of gas phase elements at STP
+
+hydrogendensity            0.08988 g/l    
+heliumdensity              0.1786 g/l     
+neondensity                0.9002 g/l     
+nitrogendensity            1.2506 g/l     
+oxygendensity              1.429 g/l      
+fluorinedensity            1.696 g/l      
+argondensity               1.784 g/l      
+chlorinedensity            3.2 g/l        
+kryptondensity             3.749 g/l      
+xenondensity               5.894 g/l      
+radondensity               9.73 g/l       
+
+# Density of liquid phase elements near room temperature
+
+brominedensity             3.1028 g/cm^3  
+mercurydensity            13.534 g/cm^3  
+
+# Density of solid elements near room temperature
+
+lithiumdensity             0.534 g/cm^3  
+potassiumdensity           0.862 g/cm^3  
+sodiumdensity              0.968 g/cm^3  
+rubidiumdensity            1.532 g/cm^3  
+calciumdensity             1.55 g/cm^3   
+magnesiumdensity           1.738 g/cm^3  
+phosphorus_white_density   1.823 g/cm^3  
+berylliumdensity           1.85 g/cm^3   
+sulfur_gamma_density       1.92 g/cm^3   
+cesiumdensity              1.93 g/cm^3
+carbon_amorphous_density   1.95 g/cm^3   # average value
+sulfur_betadensity         1.96 g/cm^3   
+sulfur_alpha_density       2.07 g/cm^3   
+carbon_graphite_density    2.267 g/cm^3  
+phosphorus_red_density     2.27 g/cm^3   # average value
+silicondensity             2.3290 g/cm^3 
+phosphorus_violet_density  2.36 g/cm^3   
+borondensity               2.37 g/cm^3   
+strontiumdensity           2.64 g/cm^3   
+phosphorus_black_density   2.69 g/cm^3   
+aluminumdensity            2.7 g/cm^3    
+bariumdensity              3.51 g/cm^3   
+carbon_diamond_density     3.515 g/cm^3  
+scandiumdensity            3.985 g/cm^3  
+selenium_vitreous_density  4.28 g/cm^3   
+selenium_alpha_density     4.39 g/cm^3   
+titaniumdensity            4.406 g/cm^3  
+yttriumdensity             4.472 g/cm^3  
+selenium_gray_density      4.81 g/cm^3   
+iodinedensity              4.933 g/cm^3  
+europiumdensity            5.264 g/cm^3  
+germaniumdensity           5.323 g/cm^3  
+radiumdensity              5.5 g/cm^3    
+arsenicdensity             5.727 g/cm^3  
+tin_alpha_density          5.769 g/cm^3  
+galliumdensity             5.91 g/cm^3   
+vanadiumdensity            6.11 g/cm^3   
+lanthanumdensity           6.162 g/cm^3  
+telluriumdensity           6.24 g/cm^3   
+zirconiumdensity           6.52 g/cm^3   
+antimonydensity            6.697 g/cm^3  
+ceriumdensity              6.77 g/cm^3   
+praseodymiumdensity        6.77 g/cm^3   
+ytterbiumdensity           6.9 g/cm^3    
+neodymiumdensity           7.01 g/cm^3   
+zincdensity                7.14 g/cm^3   
+chromiumdensity            7.19 g/cm^3   
+manganesedensity           7.21 g/cm^3   
+promethiumdensity          7.26 g/cm^3   
+tin_beta_density           7.265 g/cm^3  
+indiumdensity              7.31 g/cm^3   
+samariumdensity            7.52 g/cm^3   
+irondensity                7.874 g/cm^3  
+gadoliniumdensity          7.9 g/cm^3    
+terbiumdensity             8.23 g/cm^3   
+dysprosiumdensity          8.54 g/cm^3   
+niobiumdensity             8.57 g/cm^3   
+cadmiumdensity             8.65 g/cm^3   
+holmiumdensity             8.79 g/cm^3   
+cobaltdensity              8.9 g/cm^3    
+nickeldensity              8.908 g/cm^3  
+erbiumdensity              9.066 g/cm^3  
+polonium_alpha_density     9.196 g/cm^3  
+thuliumdensity             9.32 g/cm^3   
+polonium_beta_density      9.398 g/cm^3  
+bismuthdensity             9.78 g/cm^3   
+lutetiumdensity            9.841 g/cm^3  
+actiniumdensity           10 g/cm^3      
+molybdenumdensity         10.28 g/cm^3   
+silverdensity             10.49 g/cm^3   
+technetiumdensity         11 g/cm^3      
+leaddensity               11.34 g/cm^3   
+thoriumdensity            11.7 g/cm^3    
+thalliumdensity           11.85 g/cm^3   
+americiumdensity          12 g/cm^3      
+palladiumdensity          12.023 g/cm^3  
+rhodiumdensity            12.41 g/cm^3   
+rutheniumdensity          12.45 g/cm^3   
+berkelium_beta_density    13.25 g/cm^3   
+hafniumdensity            13.31 g/cm^3   
+curiumdensity             13.51 g/cm^3   
+berkelium_alphadensity    14.78 g/cm^3   
+californiumdensity        15.1 g/cm^3    
+protactiniumdensity       15.37 g/cm^3   
+tantalumdensity           16.69 g/cm^3   
+uraniumdensity            19.1 g/cm^3    
+tungstendensity           19.3 g/cm^3    
+golddensity               19.30 g/cm^3   
+plutoniumdensity          19.816 g/cm^3  
+neptuniumdensity          20.45 g/cm^3 # alpha form, only one at room temp
+rheniumdensity            21.02 g/cm^3   
+platinumdensity           21.45 g/cm^3   
+iridiumdensity            22.56 g/cm^3   
+osmiumdensity             22.59 g/cm^3
+
+# A few alternate names
+
+tin_gray tin_alpha_density
+tin_white tin_beta_density
+graphitedensity carbon_graphite_density
+diamonddensity carbon_diamond_density
+
+# Predicted density of elements that have not been made in sufficient
+# quantities for measurement.  
+
+franciumdensity            2.48 g/cm^3 # liquid, predicted melting point 8 degC
+astatinedensity            6.35 g/cm^3    
+einsteiniumdensity         8.84 g/cm^3    
+fermiumdensity             9.7 g/cm^3     
+nobeliumdensity            9.9 g/cm^3     
+mendeleviumdensity        10.3 g/cm^3    
+lawrenciumdensity         16 g/cm^3      
+rutherfordiumdensity      23.2 g/cm^3
+roentgeniumdensity        28.7 g/cm^3    
+dubniumdensity            29.3 g/cm^3    
+darmstadtiumdensity       34.8 g/cm^3    
+seaborgiumdensity         35 g/cm^3      
+bohriumdensity            37.1 g/cm^3    
+meitneriumdensity         37.4 g/cm^3    
+hassiumdensity            41 g/cm^3      
 
 #
 # population units
@@ -4678,15 +6974,13 @@ people                  1
 person                  people
 death                   people
 capita                  people
-percapita               /capita
+percapita               per capita
 
 # TGM dozen based unit system listed on the "dozenal" forum
 # http://www.dozenalsociety.org.uk/apps/tgm.htm.  These units are
 # proposed as an allegedly more rational alternative to the SI system.
 
-!category dozenal "Dozenal Units"
-
-Tim                     12^-4 hour         # Time
+Tim                     12^-4 hour         # Time 
 Grafut                  gravity Tim^2      # Length based on gravity
 Surf                    Grafut^2           # area
 Volm                    Grafut^3           # volume
@@ -4731,8 +7025,6 @@ Dexi-                   12^-10
 Lefi-                   12^-11
 Zennili-                12^-12
 
-!endcategory
-
 #
 # Traditional Japanese units (shakkanhou)
 #
@@ -4754,8 +7046,6 @@ Zennili-                12^-12
 # Japanese Proportions.  These are still in everyday use.  They also
 # get used as units to represent the proportion of the standard unit.
 
-!category japanese "Traditional Japanese Units"
-
 wari_proportion      1|10
 wari                 wari_proportion
 bu_proportion        1|100    # The character bu can also be read fun or bun
@@ -4776,17 +7066,17 @@ shaku              1|3.3 m
 mou                1|10000 shaku
 rin                1|1000 shaku
 bu_distance        1|100 shaku
-ja_sun             1|10 shaku
+sun                1|10 shaku
 jou_distance       10 shaku
 jou                jou_distance
 
-kanejakusun        ja_sun      # Alias to emphasize architectural name
+kanejakusun        sun      # Alias to emphasize architectural name
 kanejaku           shaku
 kanejakujou        jou
 
 # http://en.wikipedia.org/wiki/Taiwanese_units_of_measurement
 taichi             shaku   # http://zh.wikipedia.org/wiki/台尺
-taicun             ja_sun  # http://zh.wikipedia.org/wiki/台制
+taicun             sun     # http://zh.wikipedia.org/wiki/台制
 !utf8
 台尺               taichi  # via Hanyu Pinyin romanizations
 台寸               taicun
@@ -4823,12 +7113,12 @@ chou_area            10 tan_area
 # http://en.wikipedia.org/wiki/Taiwanese_units_of_measurement
 ping                 tsubo     # http://zh.wikipedia.org/wiki/坪
 jia                  2934 ping # http://zh.wikipedia.org/wiki/甲_(单位)
-#fen                  1|10 jia  # http://zh.wikipedia.org/wiki/分
+fen                  1|10 jia  # http://zh.wikipedia.org/wiki/分
 fen_area             1|10 jia  # Protection against future collisions
 !utf8
 坪                   ping      # via Hanyu Pinyin romanizations
 甲                   jia
-#分                   fen
+分                   fen
 分地                 fen_area  # Protection against future collisions
 !endutf8
 
@@ -4858,7 +7148,7 @@ tatami               jou_area
 shaku_volume         1|10 gou_volume
 gou_volume           1|10 shou
 gou                  gou_volume
-shou                 (4.9*4.9*2.7) ja_sun^3# The character shou which is
+shou                 (4.9*4.9*2.7) sun^3   # The character shou which is
                                            # the same as masu refers to a
                                            # rectangular wooden cup used to
                                            # measure liquids and cereal.
@@ -4885,13 +7175,8 @@ kwan                 kan         # This was the old pronounciation of the unit.
                                  # longer and was not changed until around
                                  # 1950.
 
-!endcategory
-
 # http://en.wikipedia.org/wiki/Taiwanese_units_of_measurement
 # says: "Volume measure in Taiwan is largely metric".
-
-!category taiwan "Taiwanese Units"
-
 taijin               kin      # http://zh.wikipedia.org/wiki/台斤
 tailiang             10 monme # http://zh.wikipedia.org/wiki/台斤
 taiqian              monme    # http://zh.wikipedia.org/wiki/台制
@@ -4900,8 +7185,6 @@ taiqian              monme    # http://zh.wikipedia.org/wiki/台制
 台兩                 tailiang
 台錢                 taiqian
 !endutf8
-
-!endcategory
 
 #
 # Australian unit
@@ -4918,119 +7201,87 @@ zentner                 50 kg
 doppelzentner           2 zentner
 pfund                   500 g
 
+# The klafter, which was used in central Europe, was derived from the span of
+# outstretched arms.
+#
+# https://en.wikipedia.org/wiki/Obsolete_Austrian_units_of_measurement
+# https://www.llv.li/files/abi/klafter-m2-en.pdf
+
+austriaklafter          1.89648384 m    # Exact definition, 23 July 1871 
+austriafoot             1|6 austriaklafter
+prussiaklafter          1.88 m
+prussiafoot             1|6 prussiaklafter
+bavariaklafter          1.751155 m
+bavariafoot             1|6 bavariaklafter
+hesseklafter            2.5 m
+hessefoot               1|6 hesseklafter
+switzerlandklafter      metricklafter
+switzerlandfoot         1|6 switzerlandklafter
+swissklafter            switzerlandklafter
+swissfoot               1|6 swissklafter
+metricklafter           1.8 m
+
+austriayoke             8 austriaklafter * 200 austriaklafter
+
+liechtensteinsquareklafter 3.596652 m^2 # Used until 2017 to measure land area 
+liechtensteinklafter  sqrt(liechtensteinsquareklafter)
+
+# The klafter was also used to measure volume of wood, generally being a stack
+# of wood one klafter wide, one klafter long, with logs 3 feet (half a klafter)
+# in length
+
+prussiawoodklafter      0.5 prussiaklafter^3
+austriawoodklafter      0.5 austriaklafter^3
+festmeter               m^3             # modern measure of wood, solid cube
+raummeter               0.7 festmeter   # Air space between the logs, stacked
+schuettraummeter        0.65 raummeter  # A cubic meter volume of split and cut
+schüttraummeter         schuettraummeter#   firewood in a loose, unordered
+                                        #   pile, not stacked.  This is called
+                                        #   "tipped".
+
+
+#
+# Swedish (Sweden) pre-metric units of 1739.
+# The metric system was adopted in 1878.
+# https://sv.wikipedia.org/wiki/Verkm%C3%A5tt
+#
+
+verklinje               2.0618125 mm
+verktum                 12 verklinje
+kvarter                 6 verktum
+fot                     2 kvarter
+aln                     2 fot
+famn                    3 aln
+
 #
 # Some traditional Russian measures
 #
+# If you would like to help expand this section and understand
+# cyrillic transliteration, let me know.  These measures are meant to
+# reflect common usage, e.g. in translated literature.  
+#
 
-!category russian "Traditional Russian Units"
+dessiatine              2400 sazhen^2    # Land measure
+dessjatine              dessiatine
 
-# length
+funt                    409.51718 grams  # similar to pound
+zolotnik                1|96 funt        # used for precious metal measure
+pood                    40 funt          # common in agricultural measure
 
-точка                   1|10 линия
-tochka                  точка
-линия                   1|10 дюим
-liniya                  линия
-дюим                    1 inch
-dyuim                   дюим
-вершок                  1.75 in
-vershok                 вершок
-пядь                    7 дюим
-piad                    пядь
-четверть                пядь
-chetvert                четверть
-фут                     1 foot
-fut                     фут
-аршин                   7|3 ft
-arshin                  аршин
-сажень                  7 ft
-sazhen                  сажень
-верста                  1500 аршин
-versta                  верста
-миля                    10500 аршин
-milia                   миля
+arshin                  (2 + 1|3) feet
+sazhen                  3 arshin         # analogous to fathom
+verst                   500 sazhen       # of similar use to mile
+versta                  verst
+borderverst             1000 sazhen
+russianmile             7 verst
 
-# area
 
-казенная_десятина       2400 сажень^2
-kazionnaya_desiatina    казенная_десятина
-official_desiatina      казенная_десятина
-владельческая_десятина  3200 сажень^2
-vladelcheskaya_desiatina владельческая_десятина
-proprietors_desiatina   владельческая_десятина
-
-# dry measures
-
-часть                   1|12 сухкружка
-chast                   часть
-сухкружка               2|5 гарнец
-drykruzhka              сухкружка
-гарнец                  200 in^3
-garnets                 гарнец
-сухведро                4 гарнец
-dryvedro                сухведро
-четверик                2 сухведро
-chetverik               четверик
-осьмина                 4 четверик
-osmina                  осьмина
-сухчетверть             2 осьмина
-drychetvert             четверть
-
-# liquid measures
-
-шкалик                  1|2 чарка
-shlalik                 шкалик
-косушка                 1|2 чарка
-kosushka                косушка
-чарка                   1|10 жидккружка
-charka                  чарка
-жидккружка              1|10 жидкведро
-fluidkruzhka            жидккружка
-штоф                    1|10 жидкведро
-shtof                   штоф
-жидкчетверть            1|8 жидкведро
-fluidchetvert           жидкчетверть
-жидкведро               750 in^3
-fuidvedro               жидкведро
-бочка                   40 жидкведро
-bochka                  бочка
-
-# common mass
-
-доля                    1|96 золотник
-dolia                   доля
-золотник                1|3 лот
-zolotnik                золотник
-лот                     1|13 фунт
-lot                     лот
-фунт                    0.903 lb
-funt                    фунт
-пуд                     40 фунт
-pood                    пуд
-берковец                10 пуд
-berkovets               берковец
-
-# apothecary mass
-
-гран                    7|5 доля
-gran                    гран
-скрупул                 20 гран
-scrupul                 скрупул
-драхма                  3 скрупул
-drachma                 драхма
-унция                   8 драхма
-uncia                   унция
-апфунт                  12 унция
-apfunt                  фунт
-
-!endcategory
 
 
 #
 # Old French distance measures, from French Weights and Measures
 # Before the Revolution by Zupko
 #
-
-!category french "French Old Measures"
 
 frenchfoot              144|443.296 m     # pied de roi, the standard of Paris.
 pied                    frenchfoot        #   Half of the hashimicubit,
@@ -5055,14 +7306,10 @@ frenchgrain             1|18827.15 kg     # Weight of a wheat grain, hence
                                           # smaller than the British grain.
 frenchpound             9216 frenchgrain
 
-!endcategory
-
 #
 # Before the Imperial Weights and Measures Act of 1824, various different
 # weights and measures were in use in different places.
 #
-
-!category scots "Scotland Measures"
 
 # Scots linear measure
 
@@ -5081,11 +7328,7 @@ scotsmile        8 scotsfurlong
 scotsrood        40 scotsfall^2
 scotsacre        4 scotsrood
 
-!endcategory
-
 # Irish linear measure
-
-!category irish "Ireland Measures"
 
 irishinch       UKinch
 irishpalm       3 irishinch
@@ -5108,11 +7351,7 @@ irishmile       8 irishfurlong   #
 irishrood       40 irishpole^2
 irishacre       4 irishrood
 
-!endcategory
-
 # English wine capacity measures (Winchester measures)
-
-!category winchester_wine "Winchester Wine Measures"
 
 winepint       1|2 winequart
 winequart      1|4 winegallon
@@ -5146,11 +7385,8 @@ winebutt       2 winehogshead
 winepipe       winebutt
 winetun        2 winebutt
 
-!endcategory
-
-!category wine "Wine and Spirits Measures"
-
 # English beer and ale measures used 1803-1824 and used for beer before 1688
+
 beerpint       1|2 beerquart
 beerquart      1|4 beergallon
 beergallon     282 UKinch^3
@@ -5164,10 +7400,6 @@ alequart       1|4 alegallon
 alegallon      beergallon
 alebarrel      34 alegallon
 alehogshead    1.5 alebarrel
-
-!endcategory
-
-!category scots "Scotland Measures"
 
 # Scots capacity measure
 
@@ -5203,10 +7435,6 @@ tronounce      1|20 tronpound
 tronpound      9520 grain
 tronstone      16 tronpound
 
-!endcategory
-
-!category irish "Ireland Measures"
-
 # Irish liquid capacity measure
 
 irishnoggin    1|4 irishpint
@@ -5229,10 +7457,6 @@ irishbushel    4 irishpeck
 irishstrike    2 irishbushel
 irishdrybarrel 2 irishstrike
 irishquarter   2 irishbarrel
-
-!endcategory
-
-!category english "English Measurements"
 
 # English Tower weights, abolished in 1528
 
@@ -5271,8 +7495,6 @@ woolsack    2 woolwey
 woolsarpler 2 woolsack
 woollast    6 woolsarpler
 
-!endcategory
-
 #
 # Ancient history units:  There tends to be uncertainty in the definitions
 #                         of the units in this section
@@ -5282,8 +7504,6 @@ woollast    6 woolsarpler
 # measures of weight were poor.  They adopted local weights in different
 # regions without distinguishing among them so that there are half a dozen
 # different Roman "standard" weight systems.
-
-!category roman "Roman Measures"
 
 romanfoot    296 mm          # There is some uncertainty in this definition
 romanfeet    romanfoot       # from which all the other units are derived.
@@ -5337,7 +7557,7 @@ sextarii        sextarius      # there is uncertainty.  Six large Roman
                                # liters, but then says the amphora is a
                                # cubic Roman foot.  This gives a value for the
                                # sextarius of 0.540 liters.  And the
-                               # encyclopedia Brittanica lists 0.53 liters for
+                               # encyclopedia Britannica lists 0.53 liters for
                                # this unit.  Both [7] and [11], which were
                                # written by scholars of weights and measures,
                                # give the value of 35.4 cubic inches.
@@ -5371,9 +7591,9 @@ quadrantal      amphora
 libra           5052 grain   # The Roman pound varied significantly
 librae          libra        # from 4210 grains to 5232 grains.  Most of
 romanpound      libra        # the standards were obtained from the weight
-romanuncia      1|12 libra   # of particular coins.  The one given here is
-unciae          romanuncia   # based on the Gold Aureus of Augustus which
-romanounce      romanuncia   # was in use from BC 27 to AD 296.
+uncia           1|12 libra   # of particular coins.  The one given here is
+unciae          uncia        # based on the Gold Aureus of Augustus which
+romanounce      uncia        # was in use from BC 27 to AD 296.
 deunx           11 uncia
 dextans         10 uncia
 dodrans         9 uncia
@@ -5396,11 +7616,7 @@ romanobol       1|2 scrupula
 romanaspound    4210 grain    # Old pound based on bronze coinage, the
                               # earliest money of Rome BC 338 to BC 268.
 
-!endcategory
-
 # Egyptian length measure
-
-!category egyptian "Egyptian Measures"
 
 egyptianroyalcubit      20.63 in    # plus or minus .2 in
 egyptianpalm            1|7 egyptianroyalcubit
@@ -5413,11 +7629,7 @@ remendigit       1|40 doubleremen # side length of 1 royal egyptian cubit.
                                   # not the same size as the digits based on
                                   # the royal cubit.
 
-!endcategory
-
 # Greek length measures
-
-!category greek "Greek Measures"
 
 greekfoot               12.45 in      # Listed as being derived from the
 greekfeet               greekfoot     # Egyptian Royal cubit in [11].  It is
@@ -5481,14 +7693,10 @@ atticmina               50 atticstaters
 attictalent             60 atticmina     # Supposedly the mass of a cubic foot
                                          # of water (whichever foot was in use)
 
-!endcategory
-
 # "Northern" cubit and foot.  This was used by the pre-Aryan civilization in
 # the Indus valley.  It was used in Mesopotamia, Egypt, North Africa, China,
 # central and Western Europe until modern times when it was displaced by
 # the metric system.
-
-!category northern_cubic "Northern Cubic and Foot"
 
 northerncubit           26.6 in           # plus/minus .2 in
 northernfoot            1|2 northerncubit
@@ -5504,12 +7712,9 @@ assyriansusi            1|20 assyrianpalm
 susi                    assyriansusi
 persianroyalcubit       7 assyrianpalm
 
-!endcategory
 
 # Arabic measures.  The arabic standards were meticulously kept.  Glass weights
 # accurate to .2 grains were made during AD 714-900.
-
-!category arabic "Arabic Measures"
 
 hashimicubit            25.56 in          # Standard of linear measure used
                                           # in Persian dominions of the Arabic
@@ -5535,8 +7740,6 @@ tradekirat              1|16 tradedirhem
 tradewukiyeh            10 tradedirhem
 traderotl               12 tradewukiyeh
 arabictradepound        traderotl
-
-!endcategory
 
 # Miscellaneous ancient units
 
@@ -5582,32 +7785,38 @@ quarter                 quarterweight
 cup                     uscup
 tablespoon              ustablespoon
 teaspoon                usteaspoon
+dollar                  US$
+cent                    $ 0.01
+penny                   cent
 minim                   minimvolume
 pony                    ponyvolume
+grand                   usgrand
 firkin                  usfirkin
 hogshead                ushogshead
 !endvar
 
-# !var UNITS_ENGLISH GB
-# hundredweight           brhundredweight
-# ton                     brton
-# scruple                 brscruple
-# fluidounce              brfluidounce
-# gallon                  brgallon
-# bushel                  brbushel
-# quarter                 brquarter
-# chaldron                brchaldron
-# cup                     brcup
-# teacup                  brteacup
-# tablespoon              brtablespoon
-# teaspoon                brteaspoon
-# penny                   brpenny
-# minim                   minimnote
-# pony                    brpony
-# grand                   brgrand
-# firkin                  brfirkin
-# hogshead                brhogshead
-# !endvar
+!var UNITS_ENGLISH GB
+hundredweight           brhundredweight
+ton                     brton
+scruple                 brscruple
+fluidounce              brfluidounce
+gallon                  brgallon
+bushel                  brbushel
+quarter                 brquarter
+chaldron                brchaldron
+cup                     brcup
+teacup                  brteacup
+tablespoon              brtablespoon
+teaspoon                brteaspoon
+dollar                  US$
+cent                    $ 0.01
+penny                   brpenny
+minim                   minimnote
+pony                    brpony
+grand                   brgrand
+firkin                  brfirkin
+hogshead                brhogshead
+!endvar
 
 !varnot UNITS_ENGLISH GB US
 !message Unknown value for environment variable UNITS_ENGLISH.  Should be GB or US.
@@ -5633,42 +7842,80 @@ hogshead                ushogshead
 # U+2150-               1|7  For some reason these characters are getting
 # U+2151-               1|9  flagged as invalid UTF8.
 # U+2152-               1|10
-ℯ                       2.71828182845904523536 #exp(1)      # U+212F, base of natural log
-e                       ℯ
-
+#⅐-               1|7   # fails under MacOS
+#⅑-               1|9   # fails under MacOS
+#⅒-               1|10  # fails under MacOS
+ℯ                       exp(1)      # U+212F, base of natural log
 µ-                      micro       # micro sign U+00B5
 μ-                      micro       # small mu U+03BC
 ångström                angstrom
-Å                       angstrom    # angstrom symbol U+212B
+Å                       angstrom    # angstrom symbol U+212B
 Å                       angstrom    # A with ring U+00C5
 röntgen                 roentgen
-#°C                      degC
-#°F                      degF
+°C                      degC
+°F                      degF
 °K                      K           # °K is incorrect notation
 °R                      degR
 °                       degree
-#℃                       degC
-#℉                       degF
-K                       K          # Kelvin symbol, U+212A
+℃                       degC
+℉                       degF
+K                       K          # Kelvin symbol, U+212A
 ℓ                       liter      # unofficial abbreviation used in some places
-
-Ω                       ohm       # Ohm symbol U+2126
+Ω                       ohm       # Ohm symbol U+2126
 Ω                       ohm       # Greek capital omega U+03A9
 ℧                       mho
 ʒ                        dram     # U+0292
 ℈                       scruple
 ℥                       ounce
 ℔                       lb
-ℎ                       planck_constant
+ℎ                       h
 ℏ                       hbar
-ħ                       hbar
 ‰                       1|1000
 ‱                       1|10000
-#′                       '        # U+2032
-#″                       "        # U+2033
+′                       '        # U+2032
+″                       "        # U+2033
 
 #
-# Square unicode symbols starting at U+3371
+# Unicode currency symbols
+#
+
+¢                       cent
+£                       britainpound
+¥                       japanyen
+€                       euro
+₩                       southkoreawon
+₪                       israelnewshekel
+₤                       lira
+# ₺                       turkeylira  # fails under MacOS
+₨                       rupee           # unofficial legacy rupee sign
+# ₹                       indiarupee      # official rupee sign # MacOS fail
+#؋                       afghanafghani    # fails under MacOS
+฿                       thailandbaht
+₡                       elsalvadorcolon # Also costaricacolon
+₣                       francefranc
+₦                       nigerianaira
+₧                       spainpeseta
+₫                       vietnamdong
+₭                       laokip 
+₮                       mongoliatugrik
+₯                       greecedrachma
+₱                       philippinepeso
+# ₲                       paraguayguarani # fails under MacOS
+#₴                       ukrainehryvnia   # fails under MacOS
+#₵                       ghanacedi        # fails under MacOS
+#₸                       kazakhstantenge  # fails under MacOS
+#₼                       azerbaijanmanat # fails under MacOS
+#₽                       russiaruble     # fails under MacOS
+#₾                       georgialari     # fails under MacOS
+﷼                       iranrial
+﹩                      $
+￠                      ¢
+￡                      £
+￥                      ¥
+￦                      ₩
+
+#
+# Square Unicode symbols starting at U+3371
 #
 
 ㍱                      hPa
@@ -5744,13 +7991,13 @@ röntgen                 roentgen
 ㎽                      mW
 ㎾                      kW
 ㎿                      MW
-㏀                      kΩ
-㏁                      MΩ
+㏀                      kΩ
+㏁                      MΩ
 ㏃                      Bq
 ㏄                      cc
 ㏅                      cd
 ㏆                      C/kg
-#㏈()                    dB
+㏈()                    dB
 ㏉                      Gy
 ㏊                      ha
 # ㏋  HP??
@@ -5765,7 +8012,7 @@ röntgen                 roentgen
 ㏔                      mb
 ㏕                      mil
 ㏖                      mol
-#㏗()                    pH
+㏗()                    pH
 ㏙                      ppm
 #   ㏚     PR???
 ㏛                      sr
@@ -5776,1316 +8023,6 @@ röntgen                 roentgen
 #㏿                      gal     Invalid on Mac
 
 !endutf8
-
-############################################################################
-#
-# Substances
-#
-############################################################################
-
-#
-# Assorted
-#
-
-!category substances "Substances"
-
-water {
-    density             mass gram / volume cm^3
-    pressure_column     pressure gram force cm^-2 / column cm
-    specific_heat       specific_energy calorie g^-1 / temperature K
-    fusion_heat         fusion_energy 79.8 calorie / fusion_mass gram
-    vaporization_heat   vaporization_energy 1160 J / vaporization_mass gram
-
-    pressure_column_0C   pressure_0C   0.99987 force gram cm^-2 / column_0C   cm
-    pressure_column_5C   pressure_5C   0.99999 force gram cm^-2 / column_5C   cm
-    pressure_column_10C  pressure_10C  0.99973 force gram cm^-2 / column_10C  cm
-    pressure_column_15C  pressure_15C  0.99913 force gram cm^-2 / column_15C  cm
-    pressure_column_18C  pressure_18C  0.99862 force gram cm^-2 / column_18C  cm
-    pressure_column_20C  pressure_20C  0.99823 force gram cm^-2 / column_20C  cm
-    pressure_column_25C  pressure_25C  0.99707 force gram cm^-2 / column_25C  cm
-    pressure_column_50C  pressure_50C  0.98807 force gram cm^-2 / column_50C  cm
-    pressure_column_100C pressure_100C 0.95838 force gram cm^-2 / column_100C cm
-}
-
-H2O                     water
-wc                      pressure_column of water
-mmH2O                   pressure of mm water
-inH2O                   pressure of inch water
-
-!symbol mercury Hg
-mercury {
-    density             mass 13.5951 gram / volume cm^3
-    pressure_column     pressure 13.5951 gram force cm^-2 / column cm
-    specific_heat       specific_energy 0.14 J g^-1 / temperature K
-    molar_mass          mass 200.59 g / amount mol
-
-    # These units, when used to form
-    # pressure measures, are not accurate
-    # because of considerations of the
-    # revised practical temperature scale.
-    pressure_column_10C pressure_10C 13.5708 force gram cm^-2 / column_10C cm
-    pressure_column_20C pressure_20C 13.5462 force gram cm^-2 / column_20C cm
-    pressure_column_23C pressure_23C 13.5386 force gram cm^-2 / column_23C cm
-    pressure_column_30C pressure_30C 13.5217 force gram cm^-2 / column_30C cm
-    pressure_column_40C pressure_40C 13.4973 force gram cm^-2 / column_40C cm
-    pressure_column_60F pressure_60F 13.5574 force gram cm^-2 / column_60F cm
-}
-
-Hg                      mercury
-mmHg                    pressure of mm mercury
-inHg                    pressure of inch mercury
-
-ammonia {
-    specific_heat       specific_energy 4.6 J g^-1 / temperature K
-}
-
-NH3                     ammonia
-
-freon {
-    ?? R-12 at 0 degrees Fahrenheit.
-    specific_heat       specific_energy 0.91 J g^-1 / temperature K
-}
-
-tissue {
-    specific_heat       specific_energy 3.5 J g^-1 / temperature K
-}
-
-diamond {
-    specific_heat       specific_energy 0.5091 J g^-1 / temperature K
-}
-
-granite {
-    specific_heat       specific_energy 0.79 J g^-1 / temperature K
-}
-
-graphite {
-    specific_heat       specific_energy 0.71 J g^-1 / temperature K
-}
-
-ice {
-    specific_heat       specific_energy 2.11 J g^-1 / temperature K
-}
-
-asphalt {
-    specific_heat       specific_energy 0.92 J g^-1 / temperature K
-}
-
-brick {
-    specific_heat       specific_energy 0.84 J g^-1 / temperature K
-}
-
-concrete {
-    specific_heat       specific_energy 0.88 J g^-1 / temperature K
-}
-
-glass_silica {
-    specific_heat       specific_energy 0.84 J g^-1 / temperature K
-}
-
-glass_flint {
-    specific_heat       specific_energy 0.503 J g^-1 / temperature K
-}
-
-glass_pyrex {
-    specific_heat       specific_energy 0.753 J g^-1 / temperature K
-}
-
-gypsum {
-    specific_heat       specific_energy 1.09 J g^-1 / temperature K
-}
-
-marble {
-    specific_heat       specific_energy 0.88 J g^-1 / temperature K
-}
-
-sand {
-    specific_heat       specific_energy 0.835 J g^-1 / temperature K
-}
-
-soil {
-    specific_heat       specific_energy 0.835 J g^-1 / temperature K
-}
-
-#
-# Fundamental particles
-#
-
-# particle wavelengths: the compton wavelength of a particle is
-# defined as h / m c where m is the mass of the particle.
-
-electron {
-    mass                const electron_mass         5.48579909070e-4 u
-    charge              const electron_charge       1.6021766208e-19 C
-    radius              const electron_radius       ((1/4 pi epsilon0) \
-                                                    charge^2 / mass c^2)
-    wavelength          const electron_wavelength   planck_constant / mass c
-    magnetic_moment     const electron_moment       -928.4764620e-26 J/T
-}
-
-electronmass            mass of electron
-electroncharge          charge of electron
-m_e                     electronmass
-
-proton {
-    mass                const proton_mass           1.007276466879 u
-    wavelength          const proton_wavelength     planck_constant / mass c
-    charge_radius       const proton_radius         0.8751e-15 m
-    magnetic_moment     const proton_moment         1.4106067873e-26 J/T
-}
-
-m_p                     mass of proton
-
-neutron {
-    mass                const neutron_mass          1.00866491588 u
-    wavelength          const neutron_wavelength    planck_constant / mass c
-    magnetic_moment     const neutron_moment        -0.96623650e-26 J/T
-}
-
-m_n                     mass of neutron
-
-deuteron {
-    mass                const deuteron_mass         2.013553212745 u
-    charge_radius       const deuteron_radius       2.1413e-15 m
-    magnetic_moment     const deuteron_moment       0.4330735040e-26 J/T
-}
-
-m_d                     mass of deuteron
-
-muon {
-    mass                const muon_mass             0.1134289257 u
-    magnetic_moment     const muon_moment           -4.49044826e-26 J/T
-}
-
-m_mu                    mass of muon
-
-helion {
-    mass                const helion_mass           3.01493224673 u
-    magnetic_moment     const helion_moment         -1.074617522e-26 J/T
-}
-
-tauparticle {
-    mass                const tau_mass              1.90749 u
-}
-
-alphaparticle {
-    mass                const alpha_mass            4.001506179127 u
-}
-
-triton {
-    mass                const triton_mass           3.01550071632 u
-    magnetic_moment     const triton_moment         1.504609503e-26 J/T
-}
-
-light {
-    speed               const light_speed           2.99792458e8 m/s
-}
-
-#
-# Celestial bodies
-#
-
-# Sidereal years from http://ssd.jpl.nasa.gov/phys_props_planets.html.  Data
-# was updated in May 2001 based on the 1992 Explanatory Supplement to the
-# Astronomical Almanac and the mean longitude rates.  Apparently the table of
-# years in that reference is incorrect.
-
-# The following are masses for planetary systems, not just the planet itself.
-# The comments give the uncertainty in the denominators.  As noted above,
-# masses are given relative to the solarmass because this is more accurate.
-# The conversion to SI is uncertain because of uncertainty in G, the
-# gravitational constant.
-#
-# Values are from http://ssd.jpl.nasa.gov/astro_constants.html
-
-# Mean radius from http://ssd.jpl.nsaa.gov/phys_props_planets.html which in
-# turn cites Global Earth Physics by CF Yoder, 1995.
-
-sun {
-    mass                const solar_mass        1.9891e30 kg
-    ?? Average earth-sun distance
-    distance            const sun_distance      1.0000010178 au
-    ?? Earth-sun distance at periphelion
-    distance_near       const sun_distance_near 1.471e11 m
-    ?? Earth-sun distance at aphelion
-    distance_far        const sun_distance_far  1.521e11 m
-    radius_equatorial   const sun_radius        695700 km
-    volume              const sun_volume        1.41e18 km^3
-    ?? Source: http://nssdc.gsfc.nasa.gov/planetary/factsheet/sunfact.html
-    luminosity          const solar_luminosity  384.6e24 W
-
-    # Some luminance data from the IES Lighting Handbook, 8th ed, 1993
-
-    ?? Clear sky.
-    illum_zenith        const sun_illum_zenith  100e3 lux
-    illum_overcast      const sun_illum_overcast 10e3 lux
-    luminance_zenith    const sun_lum_zenith    1.6e9 cd/m^2
-    luminance_horizon   const sun_lum_horizon   6e6 cd/m^2
-    ?? Average, clear sky.
-    luminance_clear     const sun_lum_clear     8000 cd/m^2
-    ?? Average, overcast sky.
-    luminance_overcast  const sun_lum_overcast  2000 cd/m^2
-}
-
-solarmass               mass of sun
-sunmass                 solarmass
-sundist                 distance of sun
-solarluminosity         luminosity of sun
-
-mercury_planet {
-    ?? ±250
-    mass                const mercury_mass      solarmass / 6023600
-    mass_old            const mercury_old       0.33022e24 kg
-    radius              const mercury_radius    2440 km
-    volume              const mercury_volume    6.083e10 km^3
-    sidereal_day        const mercury_day       58.6462 day
-    year                const mercury_year      0.2408467 julianyear
-}
-
-venus {
-    ?? ± 0.06
-    mass                const venus_mass        solarmass / 408523.71
-    mass_old            const venus_old         4.8690e24 kg
-    radius              const venus_radius      6051.84 km
-    volume              const venus_volume      9.2843e11 km^3
-    ?? Retrograde.
-    sidereal_day        const venus_day         243.01 day
-    year                const venus_year        0.61519726 julianyear
-}
-
-?? ±0.02
-earthmoonmass           solarmass / 328900.56
-?? ±3e-9
-moonearthmassratio      0.012300034
-
-earth {
-    mass                const earth_mass        earthmoonmass / ( 1 + moonearthmassratio)
-    radius              const earth_radius      6371.01 km
-    volume              const earth_volume      1.08321e12 km^3
-    sidereal_day        const earth_day         siderealday
-    year                const earth_year        siderealyear
-}
-
-moon {
-    ?? Average earth-moon distance.
-    mass                const moon_mass         moonearthmassratio mass of earth
-    radius              const moon_radius       1737.1 km
-    volume              const moon_volume       2.1958e10 km^3
-    distance            const moon_dist         3.844e8 m
-    gravity             const moon_gravity      1.62 m/s^2
-    luminance           const moon_luminance    2500 cd/m^2
-}
-
-mars {
-    ?? ±9
-    mass                const mars_mass         solarmass / 3098708
-    mass_old            const mars_old          0.64191e24 kg
-    radius              const mars_radius       3389.92 km
-    volume              const mars_volume       1.6318e11 km^3
-    sidereal_day        const mars_day          1.02595675 day
-    year                const mars_year         1.8808476 julianyear
-}
-
-jupiter {
-    ?? ±0.0008
-    mass                const jupiter_mass      solarmass / 1047.3486
-    mass_old            const jupiter_old       1898.8e24 kg
-    radius              const jupiter_radius    69911 km
-    volume              const jupiter_volume    1.4313e15 km^3
-    sidereal_day        const jupiter_day       0.41354 day
-    year                const jupiter_year      11.862615 julianyear
-}
-
-saturn {
-    ?? ±0.018
-    mass                const saturn_mass       solarmass / 3497.898
-    mass_old            const saturn_old        568.5e24 kg
-    radius              const saturn_radius     58232 km
-    volume              const saturn_volume     8.2713e14 km^3
-    sidereal_day        const saturn_day        0.4375 day
-    year                const saturn_year       29.447498 julianyear
-}
-
-uranus {
-    ?? ±0.03
-    mass                const uranus_mass       solarmass / 22902.98
-    mass_old            const uranus_old        86.625e24 kg
-    radius              const uranus_radius     25362 km
-    volume              const uranus_volume     6.833e13 km^3
-    ?? Retrograde.
-    sidereal_day        const uranus_day        0.65 day
-    year                const uranus_year       84.016846 julianyear
-}
-
-neptune {
-    ?? ±0.04
-    mass                const neptune_mass      solarmass / 19412.24
-    mass_old            const neptune_old       102.78e24 kg
-    radius              const neptune_radius    24624 km
-    volume              const neptune_volume    6.254e13 km^3
-    sidereal_day        const neptune_day       0.768 day
-    year                const neptune_year      164.79132 julianyear
-}
-
-pluto {
-    ?? ±0.07e8
-    mass                const pluto_mass        solarmass / 1.35e8
-    mass_old            const pluto_old         0.015e24 kg
-    radius              const pluto_radius      1151 km
-    ?? ±0.071e9 km^3
-    volume              const pluto_volume      7.006e9 km^3
-    sidereal_day        const pluto_day         6.3867 day
-    year                const pluto_year        247.92065 julianyear
-}
-
-#
-# Energy densities of various fuels
-#
-# Most of these fuels have varying compositions or qualities and hence their
-# actual energy densities vary.  These numbers are hence only approximate.
-#
-# E1. http://bioenergy.ornl.gov/papers/misc/energy_conv.html
-# E2. http://www.aps.org/policy/reports/popa-reports/energy/units.cfm
-# E3. http://www.ior.com.au/ecflist.html
-
-oil {
-    ?? Ton oil equivalent.  A conventional
-    ?? value for the energy released by
-    ?? burning one metric ton of oil. [18,E2]
-    ?? Note that energy per mass of petroleum
-    ?? products is fairly constant.
-    ?? Variations in volumetric energy
-    ?? density result from variations in the
-    ?? density (kg/m^3) of different fuels.
-    ?? This definition is given by the
-    ?? IEA/OECD.
-    specific_energy     energy 1e10 cal_IT / mass ton
-}
-
-tonoil                  energy of ton oil
-toe                     tonoil
-?? Conventional value for barrel of crude
-?? oil [E2].  Actual range is 5.6 - 6.3.
-barreloil               5.8 Mbtu
-
-coal {
-    ?? Energy in metric ton coal from [18].
-    ?? This is a nominal value which
-    ?? is close to the heat content
-    ?? of coal used in the 1950's.
-    specific_energy             energy 7e9 cal_IT / mass ton
-    specific_energy_bituminous  energy_bituminous 27 GJ / mass_bituminous tonne
-    specific_energy_lignite     energy_lignite 15 GJ / mass_lignite tonne
-    specific_energy_us          energy_us 22 GJ / mass_us uston
-}
-
-naturalgas {
-    ?? Energy content of natural gas.  HHV
-    ?? is for Higher Heating Value and
-    ?? includes energy from condensation
-    ?? combustion products.  LHV is for Lower
-    ?? Heating Value and excludes these.
-    ?? American publications typically report
-    ?? HHV whereas European ones report LHV.
-    energy_density_HHV  energy_HHV 1027 btu / volume_HHV ft^3
-    energy_density_LHV  energy_LHV 930 btu / volume_LHV ft^3
-}
-
-charcoal {
-    specific_energy     energy 30 GJ / mass tonne
-}
-
-wood {
-    ?? HHV, a cord weights about a tonne.
-    specific_energy_dry         energy_dry 20 GJ / mass_dry tonne
-    ?? 20% moisture content.
-    specific_energy_airdry      energy_airdry 15 GJ / mass_airdry tonne
-    specific_heat               specific_energy 1.7 J g^-1 / temperature K
-}
-
-ethanol {
-    energy_density_HHV  energy_HHV 84000 btu / volume_HHV usgallon
-    energy_density_LHV  energy_LHV 75700 btu / volume_LHV usgallon
-    specific_heat       specific_energy 2.3 J g^-1 / temperature K
-}
-
-diesel {
-    energy_density      energy 130500 btu / volume usgallon
-}
-
-gasoline {
-    energy_density_LHV  energy_LHV 115000 btu / volume_LHV usgallon
-    energy_density_HHV  energy_HHV 125000 btu / volume_HHV usgallon
-    specific_heat       specific_energy 2.22 J g^-1 / temperature K
-}
-
-heating_oil {
-    energy_density      energy 37.3 MJ / volume liter
-}
-
-fueloil {
-    ?? Low sulphur.
-    energy_density      energy 39.7 MJ / volume liter
-}
-
-propane {
-    energy_density      energy 93.3 MJ / volume m^3
-}
-
-butane {
-    energy_density      energy 124 MJ / volume m^3
-}
-
-# densities of cooking ingredients from The Cake Bible by Rose Levy Beranbaum
-# so you can convert '2 cups sugar' to grams, for example, or in the other
-# direction grams could be converted to 'cup flour_scooped'.
-
-butter {
-    density             mass 8 oz / volume uscup
-}
-
-butter_clarified {
-    density             mass 6.8 oz / volume uscup
-}
-
-cocoa_butter {
-    density             mass 9 oz / volume uscup
-}
-
-?? Vegetable shortening.
-shortening {
-    density             mass 6.75 oz / volume uscup
-}
-
-vegetable_oil {
-    density             mass 7.5 oz / volume uscup
-}
-
-olive_oil {
-    density             mass 0.918 g / volume cm^3
-    specific_heat       specific_energy 1.97 J g^-1 / temperature K
-}
-
-# The density of flour depends on the
-# measuring method.  "Scooped",  or
-# "dip and sweep" refers to dipping a
-# measure into a bin, and then sweeping
-# the excess off the top.  "Spooned"
-# means to lightly spoon into a measure
-# and then sweep the top.  Sifted means
-# sifting the flour directly into a
-# measure and then sweeping the top.
-
-cakeflour {
-    density_sifted      mass_sifted 3.5 oz / volume_sifted uscup
-    density_spooned     mass_spooned 4 oz / volume_spooned uscup
-    density_scooped     mass_scooped 4.5 oz / volume_scooped uscup
-}
-
-flour {
-    density_sifted      mass_sifted 4 oz / volume_sifted uscup
-    density_spooned     mass_spooned 4.25 oz / volume_spooned uscup
-    density_scooped     mass_scooped 5 oz / volume_scooped uscup
-}
-
-breadflour {
-    density_sifted      mass_sifted 4.25 oz / volume_sifted uscup
-    density_spooned     mass_spooned 4.5 oz / volume_spooned uscup
-    density_scooped     mass_scooped 5.5 oz / volume_scooped uscup
-}
-
-cornstarch {
-    density             mass 120 grams / volume uscup
-}
-
-?? Alkalized Dutch processed cocoa.
-dutchcocoa {
-    density_sifted      mass_sifted 75 g / volume_sifted uscup
-    density_spooned     mass_spooned 92 g / volume_spooned uscup
-    density_scooped     mass_scooped 95 g / volume_scooped uscup
-}
-
-?? Non-alkalized cocoa.
-cocoa {
-    density_sifted      mass_sifted 75 g / volume_sifted uscup
-    density_spooned     mass_spooned 82 g / volume_spooned uscup
-    density_scooped     mass_scooped 95 g / volume_scooped uscup
-}
-
-heavycream {
-    density             mass 232 g / volume uscup
-}
-
-milk {
-    density             mass 242 g / volume uscup
-}
-
-sourcream {
-    density             mass 242 g / volume uscup
-}
-
-molasses {
-    density             mass 11.25 oz / volume uscup
-}
-
-cornsyrup {
-    density             mass 11.5 oz / volume uscup
-}
-
-honey {
-    density             mass 11.75 oz / volume uscup
-}
-
-sugar {
-    density             mass 200 g / volume uscup
-    specific_heat       specific_energy 1.244 J g^-1 / temperature K
-}
-
-powdered_sugar {
-    density             mass 4 oz / volume uscup
-}
-
-brownsugar_light {
-    ?? Packed.
-    density             mass 217 g / volume uscup
-}
-
-brownsugar_dark {
-    density             mass 239 g / volume uscup
-}
-
-baking_powder {
-    density             mass 4.6 grams / volume ustsp
-}
-
-salt {
-    density             mass 6 g / volume ustsp
-}
-
-koshersalt {
-    ?? Diamond Crystal kosher salt
-    density_dc           dc_mass 2.8 g / dc_volume ustsp
-    ?? Morton kosher salt
-    density_morton       morton_mass 4.8 g / morton_volume ustsp
-}
-
-?? USA large egg.
-egg {
-    mass_shelled        const egg_shelled  50 grams
-    mass_white          const egg_white    30 grams
-    mass_yolk           const egg_yolk     18.6 grams
-    volume              const egg_volume   (3 ustbsp + 1|2 ustsp)
-    volume_white        const egg_white    2 tbsp
-    volume_yolk         const egg_yolk     3.5 ustsp
-}
-
-#
-# Atomic weights.  The atomic weight of an element is the ratio of the mass of
-# a mole of the element to 1|12 of a mole of Carbon 12.  The Standard Atomic
-# Weights apply to the elements as they occur naturally on earth.  Elements
-# which do not occur naturally or which occur with wide isotopic variability do
-# not have Standard Atomic Weights.  For these elements, the atomic weight is
-# based on the longest lived isotope, as marked in the comments.  In some
-# cases, the comment for these entries also gives a number which is an atomic
-# weight for a different isotope that may be of more interest than the longest
-# lived isotope.
-#
-
-actinium {
-    molar_mass      mass 227.0278 g / amount mol
-}
-
-!symbol aluminum Al
-aluminum {
-    molar_mass      mass 26.981539 g / amount mol
-    specific_heat   specific_energy 0.91 J g^-1 / temperature K
-}
-
-americium {
-    ?? Longest lived. 241.06
-    molar_mass      mass 243.0614 g / amount mol
-}
-
-!symbol antimony Sb
-antimony {
-    molar_mass      mass 121.760 g / amount mol
-    specific_heat   specific_energy 0.21 J g^-1 / temperature K
-}
-
-!symbol argon Ar
-argon {
-    molar_mass      mass 39.948 g / amount mol
-    specific_heat   specific_energy 0.5203 J g^-1 / temperature K
-}
-
-!symbol arsenic As
-arsenic {
-    molar_mass      mass 74.92159 g / amount mol
-}
-
-astatine {
-    ?? Longest lived.
-    molar_mass      mass 209.9871 g / amount mol
-}
-
-!symbol barium Ba
-barium {
-    molar_mass      mass 137.327 g / amount mol
-    specific_heat   specific_energy 0.20 J g^-1 / temperature K
-}
-
-berkelium {
-    ?? Longest lived. 249.08
-    molar_mass      mass 247.0703 g / amount mol
-}
-
-!symbol beryllium Be
-beryllium {
-    molar_mass      mass 9.012182 g / amount mol
-    specific_heat   specific_energy 1.83 J g^-1 / temperature K
-}
-
-!symbol bismuth Bi
-bismuth {
-    molar_mass      mass 208.98037 g / amount mol
-    specific_heat   specific_energy 0.13 J g^-1 / temperature K
-}
-
-bohrium {
-    molar_mass      mass 272.13826 g / amount mol
-}
-
-!symbol boron B
-boron {
-    molar_mass      mass 10.811 g / amount mol
-}
-
-!symbol bromine Br
-bromine {
-    molar_mass      mass 79.904 g / amount mol
-}
-
-!symbol cadmium Cd
-cadmium {
-    molar_mass      mass 112.411 g / amount mol
-    specific_heat   specific_energy 0.23 J g^-1 / temperature K
-}
-
-!symbol calcium Ca
-calcium {
-    molar_mass      mass 40.078 g / amount mol
-}
-
-californium {
-    ?? Longest lived. 252.08
-    molar_mass      mass 251.0796 g / amount mol
-}
-
-!symbol carbon C
-carbon {
-    molar_mass      mass 12.011 g / amount mol
-}
-
-!symbol cerium Ce
-cerium {
-    molar_mass      mass 140.115 g / amount mol
-}
-
-!symbol cesium Cs
-cesium {
-    molar_mass      mass 132.90543 g / amount mol
-    specific_heat   specific_energy 0.24 J g^-1 / temperature K
-}
-
-!symbol chlorine Cl
-chlorine {
-    molar_mass      mass 35.4527 g / amount mol
-}
-
-!symbol chromium Cr
-chromium {
-    molar_mass      mass 51.9961 g / amount mol
-    specific_heat   specific_energy 0.46 J g^-1 / temperature K
-}
-
-!symbol cobalt Co
-cobalt {
-    molar_mass      mass 58.93320 g / amount mol
-    specific_heat   specific_energy 0.42 J g^-1 / temperature K
-}
-
-copernicium {
-    molar_mass      mass 285.17712 g / amount mol
-}
-
-!symbol copper Cu
-copper {
-    molar_mass      mass 63.546 g / amount mol
-    specific_heat   specific_energy 0.39 J g^-1 / temperature K
-}
-
-curium {
-    molar_mass      mass 247.0703 g / amount mol
-}
-
-darmstadtium {
-    molar_mass      mass 281.16451 g / amount mol
-}
-
-!symbol deuterium D
-deuterium {
-    molar_mass      mass 2.0141017778 g / amount mol
-}
-
-dubnium {
-    molar_mass      mass 268.12567 g / amount mol
-}
-
-!symbol dysprosium Dy
-dysprosium {
-    molar_mass      mass 162.50 g / amount mol
-}
-
-einsteinium {
-    ?? Longest lived.
-    molar_mass      mass 252.083 g / amount mol
-}
-
-!symbol erbium Er
-erbium {
-    molar_mass      mass 167.26 g / amount mol
-}
-
-!symbol europium Eu
-europium {
-    molar_mass      mass 151.965 g / amount mol
-}
-
-fermium {
-    ?? Longest lived.
-    molar_mass      mass 257.0951 g / amount mol
-}
-
-flerovium {
-    molar_mass      mass 289.19042 g / amount mol
-}
-
-!symbol fluorine F
-fluorine {
-    molar_mass      mass 18.9984032 g / amount mol
-}
-
-francium {
-    ?? Longest lived
-    molar_mass      mass 223.0197 g / amount mol
-}
-
-!symbol gadolinium Gd
-gadolinium {
-    molar_mass      mass 157.25 g / amount mol
-}
-
-!symbol gallium Ga
-gallium {
-    molar_mass      mass 69.723 g / amount mol
-    specific_heat   specific_energy 0.37 J g^-1 / temperature K
-}
-
-!symbol germanium Ge
-germanium {
-    molar_mass      mass 72.61 g / amount mol
-    specific_heat   specific_energy 0.32 J g^-1 / temperature K
-}
-
-!symbol gold Au
-gold {
-    molar_mass      mass 196.96654 g / amount mol
-    specific_heat   specific_energy 0.13 J g^-1 / temperature K
-}
-
-!symbol hafnium Hf
-hafnium {
-    molar_mass      mass 178.49 g / amount mol
-    specific_heat   specific_energy 0.14 J g^-1 / temperature K
-}
-
-hassium {
-    molar_mass      mass 270.13429 g / amount mol
-}
-
-!symbol helium He
-helium {
-    molar_mass      mass 4.002602 g / amount mol
-}
-
-!symbol holmium Ho
-holmium {
-    molar_mass      mass 164.93032 g / amount mol
-    specific_heat   specific_energy 5.1932 J g^-1 / temperature K
-}
-
-!symbol hydrogen H
-hydrogen {
-    molar_mass      mass 1.00794 g / amount mol
-    specific_heat   specific_energy 14.3 J g^-1 / temperature K
-}
-
-!symbol indium In
-indium {
-    molar_mass      mass 114.818 g / amount mol
-    specific_heat   specific_energy 0.24 J g^-1 / temperature K
-}
-
-!symbol iodine I
-iodine {
-    molar_mass      mass 126.90447 g / amount mol
-    specific_heat   specific_energy 2.15 J g^-1 / temperature K
-}
-
-!symbol iridium Ir
-iridium {
-    molar_mass      mass 192.217 g / amount mol
-    specific_heat   specific_energy 0.13 J g^-1 / temperature K
-}
-
-!symbol iron Fe
-iron {
-    molar_mass      mass 55.845 g / amount mol
-    specific_heat   specific_energy 0.45 J g^-1 / temperature K
-}
-
-!symbol krypton Kr
-krypton {
-    molar_mass      mass 83.80 g / amount mol
-}
-
-!symbol lanthanum La
-lanthanum {
-    molar_mass      mass 138.9055 g / amount mol
-    specific_heat   specific_energy 0.195 J g^-1 / temperature K
-}
-
-lawrencium {
-    ?? Longest lived.
-    molar_mass      mass 262.11 g / amount mol
-}
-
-!symbol lead Pb
-lead {
-    molar_mass      mass 207.2 g / amount mol
-    specific_heat   specific_energy 0.13 J g^-1 / temperature K
-}
-
-!symbol lithium Li
-lithium {
-    molar_mass      mass 6.941 g / amount mol
-    specific_heat   specific_energy 3.57 J g^-1 / temperature K
-}
-
-livermorium {
-    molar_mass      mass 293.20449 g / amount mol
-}
-
-!symbol lutetium Lu
-lutetium {
-    molar_mass      mass 174.967 g / amount mol
-    specific_heat   specific_energy 0.15 J g^-1 / temperature K
-}
-
-!symbol magnesium Mg
-magnesium {
-    molar_mass      mass 24.3050 g / amount mol
-    specific_heat   specific_energy 1.05 J g^-1 / temperature K
-}
-
-!symbol manganese Mn
-manganese {
-    molar_mass      mass 54.93805 g / amount mol
-    specific_heat   specific_energy 0.48 J g^-1 / temperature K
-}
-
-meitnerium {
-    molar_mass      mass 276.15159 g / amount mol
-}
-
-mendelevium {
-    ?? Longest lived
-    molar_mass      mass 258.10 g / amount mol
-}
-
-!symbol molybdenum Mo
-molybdenum {
-    molar_mass      mass 95.94 g / amount mol
-    specific_heat   specific_energy 0.25 J g^-1 / temperature K
-}
-
-!symbol neodymium Nd
-neodymium {
-    molar_mass      mass 144.24 g / amount mol
-}
-
-!symbol neon Ne
-neon {
-    molar_mass      mass 20.1797 g / amount mol
-}
-
-neptunium {
-    molar_mass      mass 237.0482 g / amount mol
-}
-
-!symbol nickel Ni
-nickel {
-    molar_mass      mass 58.6934 g / amount mol
-    specific_heat   specific_energy 0.44 J g^-1 / temperature K
-}
-
-!symbol niobium Nb
-niobium {
-    molar_mass      mass 92.90638 g / amount mol
-}
-
-!symbol nitrogen N
-nitrogen {
-    molar_mass      mass 14.00674 g / amount mol
-}
-
-nobelium {
-    ?? Longest lived.
-    molar_mass      mass 259.1009 g / amount mol
-}
-
-!symbol osmium Os
-osmium {
-    molar_mass      mass 190.23 g / amount mol
-    specific_heat   specific_energy 0.13 J g^-1 / temperature K
-}
-
-!symbol oxygen O
-oxygen {
-    molar_mass      mass 15.9994 g / amount mol
-}
-
-!symbol palladium Pa
-palladium {
-    molar_mass      mass 106.42 g / amount mol
-    specific_heat   specific_energy 0.24 J g^-1 / temperature K
-}
-
-!symbol phosphorus P
-phosphorus {
-    molar_mass      mass 30.973762 g / amount mol
-}
-
-!symbol platinum Pt
-platinum {
-    molar_mass      mass 195.08 g / amount mol
-    specific_heat   specific_energy 0.13 J g^-1 / temperature K
-}
-
-!symbol plutonium Pu
-plutonium {
-    ?? Longest lived. 239.05
-    molar_mass      mass 244.0642 g / amount mol
-    specific_heat   specific_energy 0.13 J g^-1 / temperature K
-}
-
-polonium {
-    ?? Longest lived. 209.98
-    molar_mass      mass 208.9824 g / amount mol
-}
-
-!symbol potassium K
-potassium {
-    molar_mass      mass 39.0983 g / amount mol
-    specific_heat   specific_energy 0.75 J g^-1 / temperature K
-}
-
-!symbol praseodymium Pr
-praseodymium {
-    molar_mass      mass 140.90765 g / amount mol
-}
-
-promethium {
-    ?? Longest lived. 146.92
-    molar_mass      mass 144.9127 g / amount mol
-}
-
-protactinium {
-    molar_mass      mass 231.03588 g / amount mol
-}
-
-radium {
-    molar_mass      mass 226.0254 g / amount mol
-}
-
-radon {
-    ?? Longest lived.
-    molar_mass      mass 222.0176 g / amount mol
-}
-
-!symbol rhenium Re
-rhenium {
-    molar_mass      mass 186.207 g / amount mol
-    specific_heat   specific_energy 0.14 J g^-1 / temperature K
-}
-
-!symbol rhodium Rh
-rhodium {
-    molar_mass      mass 102.90550 g / amount mol
-    specific_heat   specific_energy 0.24 J g^-1 / temperature K
-}
-
-roentgenium {
-    molar_mass      mass 280.16514 g / amount mol
-}
-
-!symbol rubidium Rb
-rubidium {
-    molar_mass      mass 85.4678 g / amount mol
-    specific_heat   specific_energy 0.36 J g^-1 / temperature K
-}
-
-!symbol ruthenium Ru
-ruthenium {
-    molar_mass      mass 101.07 g / amount mol
-    specific_heat   specific_energy 0.24 J g^-1 / temperature K
-}
-
-rutherfordium {
-    molar_mass      mass 267.12179 g / amount mol
-}
-
-!symbol samarium Sm
-samarium {
-    molar_mass      mass 150.36 g / amount mol
-}
-
-!symbol scandium Sc
-scandium {
-    molar_mass      mass 44.955910 g / amount mol
-    specific_heat   specific_energy 0.57  J g^-1 / temperature K
-}
-
-seaborgium {
-    molar_mass      mass 271.13393 g / amount mol
-}
-
-!symbol selenium Se
-selenium {
-    molar_mass      mass 78.96 g / amount mol
-    specific_heat   specific_energy 0.32 J g^-1 / temperature K
-}
-
-!symbol silicon Si
-silicon {
-    molar_mass      mass 28.0855 g / amount mol
-    specific_heat   specific_energy 0.71 J g^-1 / temperature K
-}
-
-!symbol silver Ag
-silver {
-    molar_mass      mass 107.8682 g / amount mol
-    specific_heat   specific_energy 0.23 J g^-1 / temperature K
-}
-
-!symbol sodium Na
-sodium {
-    molar_mass      mass 22.989768 g / amount mol
-    specific_heat   specific_energy 1.21 J g^-1 / temperature K
-}
-
-!symbol strontium Sr
-strontium {
-    molar_mass      mass 87.62 g / amount mol
-    specific_heat   specific_energy 0.30 J g^-1 / temperature K
-}
-
-!symbol sulfur S
-sulfur {
-    molar_mass      mass 32.066 g / amount mol
-}
-
-!symbol tantalum Ta
-tantalum {
-    molar_mass      mass 180.9479 g / amount mol
-    specific_heat   specific_energy 0.14 J g^-1 / temperature K
-}
-
-technetium {
-    ?? Longest lived. 98.906
-    molar_mass      mass 97.9072 g / amount mol
-}
-
-!symbol tellurium Te
-tellurium {
-    molar_mass      mass 127.60 g / amount mol
-}
-
-!symbol terbium Tb
-terbium {
-    molar_mass      mass 158.92534 g / amount mol
-}
-
-!symbol thallium Tl
-thallium {
-    molar_mass      mass 204.3833 g / amount mol
-    specific_heat   specific_energy 0.13 J g^-1 / temperature K
-}
-
-!symbol thorium Th
-thorium {
-    molar_mass      mass 232.0381 g / amount mol
-    specific_heat   specific_energy 0.13 J g^-1 / temperature K
-}
-
-!symbol thullium Tm
-thullium {
-    molar_mass      mass 168.93421 g / amount mol
-}
-
-!symbol tin Sn
-tin {
-    molar_mass      mass 118.710 g / amount mol
-    specific_heat   specific_energy 0.21 J g^-1 / temperature K
-}
-
-!symbol titanium Ti
-titanium {
-    molar_mass      mass 47.867 g / amount mol
-    specific_heat   specific_energy 0.54 J g^-1 / temperature K
-}
-
-!symbol tungsten W
-tungsten {
-    molar_mass      mass 183.84 g / amount mol
-    specific_heat   specific_energy 0.13 J g^-1 / temperature K
-}
-
-ununoctium {
-    molar_mass      mass 294.21392 g / amount mol
-}
-
-ununpentium {
-    molar_mass      mass 288.19274 g / amount mol
-}
-
-ununseptium {
-    molar_mass      mass 292.20746 g / amount mol
-}
-
-ununtrium {
-    molar_mass      mass 284.17873 g / amount mol
-}
-
-!symbol uranium U
-uranium {
-    molar_mass      mass 238.0289 g / amount mol
-    specific_heat   specific_energy 0.12 J g^-1 / temperature K
-    molar_mass_235  mass_235 235.0439299 g / amount_235 mol
-
-    ?? Total energy from uranium fission.  Actual efficiency of
-    ?? nuclear power plants is around 30%-40%.  Note also that some
-    ?? reactors use enriched uranium around 3% U-235.  Uranium during
-    ?? processing or use may be in a compound of uranium oxide or
-    ?? uranium hexafluoride, in which case the energy density would be
-    ?? lower depending on how much uranium is in the compound.
-    specific_energy_235_fission fission_energy 200 MeV / mass ((235.0439299 g/mol) / avogadro)
-}
-
-!symbol vanadium V
-vanadium {
-    molar_mass      mass 50.9415 g / amount mol
-    specific_heat   specific_energy 0.39 J g^-1 / temperature K
-}
-
-!symbol xenon Xe
-xenon {
-    molar_mass      mass 131.29 g / amount mol
-}
-
-!symbol ytterbium Yb
-ytterbium {
-    molar_mass      mass 173.04 g / amount mol
-}
-
-!symbol yttrium Y
-yttrium {
-    molar_mass      mass 88.90585 g / amount mol
-    specific_heat   specific_energy 0.30 J g^-1 / temperature K
-}
-
-!symbol zinc Zn
-zinc {
-    molar_mass      mass 65.39 g / amount mol
-    specific_heat   specific_energy 0.39 J g^-1 / temperature K
-}
-
-!symbol zirconium Zr
-zirconium {
-    molar_mass      mass 91.224 g / amount mol
-    specific_heat   specific_energy 0.27 J g^-1 / temperature K
-}
-
-# The atmospheric composition listed is from NASA Earth Fact Sheet (accessed
-# 28 August 2015)
-# http://nssdc.gsfc.nasa.gov/planetary/factsheet/earthfact.html
-# Numbers do not add up to exactly 100% due to roundoff and uncertainty Water
-# is highly variable, typically makes up about 1%
-
-?? Average molecular weight of air.
-air               78.08   % nitrogen 2 \
-              +   20.95   % oxygen 2 \
-              + 9340    ppm argon \
-              +  400    ppm (carbon + oxygen 2) \
-              +   18.18 ppm neon \
-              +    5.24 ppm helium \
-              +    1.7  ppm (carbon + 4 hydrogen) \
-              +    1.14 ppm krypton \
-              +    0.55 ppm hydrogen 2
-
-# Various abbreviations used in organic chemistry.
-
-!symbol methyl Me
-methyl {
-    molar_mass      mass 15.03482 g / amount mol
-}
-
-!symbol ethyl Et
-ethyl {
-    molar_mass      mass 29.0617 g / amount mol
-}
-
-!symbol acetyl Ac
-acetyl {
-    molar_mass      mass 43.04522 g / amount mol
-}
-
-!symbol phenyl Ph
-phenyl {
-    molar_mass      mass 77.1057 g / amount mol
-}
-
-# Biological or immunological activity of reference preparations.
-
-prolactin {
-    # 4th International Standard for Prolactin, human, pituitary [WHO/BS/2016.2292]
-    # <https://apps.who.int/iris/handle/10665/253053>
-    biological_activity_density     mass 3.2 µg / biological_activity 67 mIU
-}
-
-# Steroid hormones.
-
-progesterone            C21H30O2
-dehydroepiandrosterone  C19H28O2
-androstenediol          C19H30O2
-androstenedione         C19H26O2
-testosterone            C19H28O2
-dihydrotestosterone     C19H30O2
-estrone                 C18H22O2
-estradiol               C18H24O2
-estriol                 C18H24O3
-estetrol                C18H24O4
-
-!endcategory
 
 ############################################################################
 #
@@ -7105,7 +8042,7 @@ estetrol                C18H24O4
 
 ############################################################################
 #
-# The following units were in the unix units database but do not appear in
+# The following units were in the Unix units database but do not appear in
 # this file:
 #
 #      wey        used for cheese, salt and other goods.  Measured mass or
@@ -7125,3 +8062,4 @@ estetrol                C18H24O4
 #                 a single channel occupied for one hour.
 #
 ############################################################################
+


### PR DESCRIPTION
The GNU units(1) database file used was in 2015; given the SI units redefinition in 2019 following CODATA 2018, this is probably worth including to keep units relevant.

This simply includes `definitions.units` and `currency.units` version 3.09, directly pulled from version 2.21 ([source code]); I have made no edits myself.

Other than general reordering of units, major differences include:
- The SI (2019) redefinition of base units;
- CODATA 2018, and the addition of several data sources;
- All `x of y` substance properties are replaced with bare `yx` names (eg `density of water` -> `waterdensity`)

The latter change is a bit of a significant one that may affect the efforts made for #2 and #12: the definitions file no longer has substance namespaces, merely units. As such, I'm not sure if this will break certain behaviours, unfortunately.

I guess an `x of y` -> `yx` macro might maintain the backwards compatibility of the syntax — it _would_ make bizarre phrases such as `lar of dol` technically valid, but I would consider that a charming easter egg :)

[source code]: http://ftp.gnu.org/gnu/units/