### PR TITLE
Fixed CTRL+C behaviour

### DIFF
--- a/src/repl.rs
+++ b/src/repl.rs
@@ -93,7 +93,8 @@ pub fn interactive(config: &Config) -> Result<()> {
                 };
                 println!();
             }
-            Err(ReadlineError::Eof) | Err(ReadlineError::Interrupted) => {
+            Err(ReadlineError::Interrupted) => {}
+            Err(ReadlineError::Eof) => {
                 save_history(&mut rl);
                 break;
             }


### PR DESCRIPTION
Upon CTRL+C the program currently exits. This commit changes the CTRL+C behaviour to match expected shell behaviour.