### PR TITLE
Make "now" respect system timezone

### DIFF
--- a/core/src/context.rs
+++ b/core/src/context.rs
@@ -8,7 +8,7 @@ use crate::numeric::Numeric;
 use crate::reply::NotFoundError;
 use crate::search;
 use crate::substance::Substance;
-use chrono::{DateTime, TimeZone, Utc};
+use chrono::{DateTime, Local, TimeZone};
 use std::collections::{BTreeMap, BTreeSet};
 
 /// The evaluation context that contains unit definitions.
@@ -28,7 +28,7 @@ pub struct Context {
     pub substances: BTreeMap<String, Substance>,
     pub substance_symbols: BTreeMap<String, String>,
     pub temporaries: BTreeMap<String, Number>,
-    pub now: DateTime<Utc>,
+    pub now: DateTime<Local>,
     pub short_output: bool,
     pub use_humanize: bool,
 }
@@ -47,7 +47,7 @@ impl Context {
             short_output: false,
             use_humanize: true,
 
-            now: Utc.ymd(2000, 1, 1).and_hms(0, 0, 0),
+            now: Local.timestamp(0, 0),
 
             dimensions: BTreeSet::new(),
             prefixes: vec![],
@@ -66,12 +66,12 @@ impl Context {
         }
     }
 
-    pub fn set_time(&mut self, time: DateTime<Utc>) {
+    pub fn set_time(&mut self, time: DateTime<Local>) {
         self.now = time;
     }
 
     pub fn update_time(&mut self) {
-        self.now = Utc::now();
+        self.now = Local::now();
     }
 
     pub fn load_dates(&mut self, mut dates: Vec<Vec<DatePattern>>) {

--- a/core/src/date.rs
+++ b/core/src/date.rs
@@ -9,7 +9,7 @@ use crate::context::Context;
 use crate::number::{Dimension, Number};
 use crate::numeric::Numeric;
 use chrono::format::Parsed;
-use chrono::{DateTime, Duration, FixedOffset, TimeZone, Utc, Weekday};
+use chrono::{DateTime, Duration, FixedOffset, Local, TimeZone, Weekday};
 use chrono_tz::Tz;
 use std::iter::Peekable;
 use std::str::FromStr;
@@ -288,7 +288,7 @@ impl GenericDateTime {
 }
 
 fn attempt(
-    now: DateTime<Utc>,
+    now: DateTime<Local>,
     date: &[DateToken],
     pat: &[DatePattern],
 ) -> Result<GenericDateTime, (String, usize)> {
@@ -760,7 +760,7 @@ mod tests {
             Number(x.into(), None)
         }
 
-        let now = Utc::now();
+        let now = Local::now();
 
         macro_rules! check_attempt {
             ($date:expr, $pat:expr) => {{

--- a/core/src/eval.rs
+++ b/core/src/eval.rs
@@ -18,7 +18,7 @@ use crate::reply::{
 use crate::search;
 use crate::substance::SubstanceGetError;
 use crate::value::{Show, Value};
-use chrono::FixedOffset;
+use chrono::{DateTime, FixedOffset};
 use std::collections::BTreeMap;
 use std::rc::Rc;
 
@@ -29,9 +29,11 @@ impl Context {
         use std::ops::*;
 
         match *expr {
-            Expr::Unit { ref name } if name == "now" => Ok(Value::DateTime(
-                date::GenericDateTime::Fixed(self.now.with_timezone(&FixedOffset::east(0))),
-            )),
+            Expr::Unit { ref name } if name == "now" => {
+                Ok(Value::DateTime(date::GenericDateTime::Fixed(
+                    DateTime::from_utc(self.now.naive_utc(), *self.now.offset()),
+                )))
+            }
             Expr::Unit { ref name } => self
                 .lookup(name)
                 .map(Value::Number)

--- a/rink-js/src/lib.rs
+++ b/rink-js/src/lib.rs
@@ -1,4 +1,4 @@
-use chrono::{TimeZone, Utc};
+use chrono::{Local, TimeZone};
 use js_sys::Date;
 use rink_core;
 use rink_core::ast;
@@ -87,7 +87,8 @@ impl Context {
         let sec = date.get_utc_seconds();
         let millis = date.get_utc_milliseconds();
         self.context.set_time(
-            Utc.ymd(year as i32, month, day)
+            Local
+                .ymd(year as i32, month, day)
                 .and_hms_milli(hour, min, sec, millis),
         );
     }


### PR DESCRIPTION
Most users probably want to manipulate time relative to the present in
their local timezone. This brings rink's functionality closer to similar
tools.

In date(1):

	> date -d 'now + 1 hour'
	Fri 23 Jul 09:54:02 CEST 2021

Before:

	> now
	2021-07-23 06:54:05.699222874 +00:00 (now)
	> now + 1 hour
	2021-07-23 07:54:10.940110380 +00:00 (in an hour)

After:

	> now
	2021-07-23 08:54:13.219044877 +02:00 (now)
	> now + 1 hour
	2021-07-23 09:54:15.555096329 +02:00 (in an hour)