### PR TITLE
Draft: Add variable definitions via let

### DIFF
--- a/core/src/ast/query.rs
+++ b/core/src/ast/query.rs
@@ -21,6 +21,7 @@ pub enum Query {
     UnitsFor(Expr),
     Search(String),
     Error(String),
+    Let(String, Expr),
 }
 
 impl fmt::Display for Conversion {

--- a/core/src/context.rs
+++ b/core/src/context.rs
@@ -89,9 +89,6 @@ impl Context {
             if name == "ans" || name == "ANS" || name == "_" {
                 return ctx.previous_result.clone();
             }
-            if let Some(v) = ctx.variables.get(name).cloned() {
-                return Some(v);
-            }
             if let Some(v) = ctx.temporaries.get(name).cloned() {
                 return Some(v);
             }
@@ -108,6 +105,9 @@ impl Context {
                         unit: unit.clone(),
                     });
                 }
+            }
+            if let Some(v) = ctx.variables.get(name).cloned() {
+                return Some(v);
             }
             None
         }

--- a/core/src/context.rs
+++ b/core/src/context.rs
@@ -32,6 +32,7 @@ pub struct Context {
     pub short_output: bool,
     pub use_humanize: bool,
     pub previous_result: Option<Number>,
+    pub variables: BTreeMap<String, Number>,
 }
 
 impl Default for Context {
@@ -65,6 +66,7 @@ impl Context {
             substance_symbols: BTreeMap::new(),
             temporaries: BTreeMap::new(),
             previous_result: None,
+            variables: BTreeMap::new(),
         }
     }
 
@@ -86,6 +88,9 @@ impl Context {
         fn inner(ctx: &Context, name: &str) -> Option<Number> {
             if name == "ans" || name == "ANS" || name == "_" {
                 return ctx.previous_result.clone();
+            }
+            if let Some(v) = ctx.variables.get(name).cloned() {
+                return Some(v);
             }
             if let Some(v) = ctx.temporaries.get(name).cloned() {
                 return Some(v);

--- a/core/src/eval.rs
+++ b/core/src/eval.rs
@@ -701,7 +701,7 @@ impl Context {
     }
 
     /// Evaluates an expression, include `->` conversions.
-    pub fn eval_outer(&self, expr: &Query) -> Result<QueryReply, QueryError> {
+    pub fn eval_outer(&mut self, expr: &Query) -> Result<QueryReply, QueryError> {
         match *expr {
             Query::Expr(Expr::Unit { ref name })
                 if {
@@ -1178,7 +1178,18 @@ impl Context {
                         s.to_reply(self).map_err(QueryError::generic)?,
                     )),
                 }
-            }
+            },
+            Query::Let(ref var_name, ref expr) => {
+                // todo: check whether already defined with self.lookup(var_name)
+                let res = self.eval(expr)?;
+                if let Value::Number(num) = res {
+                    let parts = num.to_parts(self);
+                    self.variables.insert(var_name.clone(), num);
+                    Ok(QueryReply::Number(parts))
+                } else {
+                    Err(QueryError::generic("let expressions currently only supported for numeric results".to_string()))
+                }
+            },
             Query::Error(ref e) => Err(QueryError::generic(e.clone())),
         }
     }

--- a/core/src/text_query.rs
+++ b/core/src/text_query.rs
@@ -753,6 +753,17 @@ pub fn parse_query(iter: &mut Iter<'_>) -> Query {
                 return Query::Search(s.clone());
             }
         }
+        Some(Token::Ident(ref s)) if s == "let" => {
+            iter.next();
+            if let Some(Token::Ident(ref s)) = iter.peek().cloned() {
+               iter.next();
+               if let Some(Token::Equals) = iter.peek() {
+                   iter.next();
+                   return Query::Let(s.clone(), parse_eq(iter));
+               }
+            }
+            return Query::Error("let needs to have form `let var = expr`".to_string());
+        }
         _ => (),
     }
     let left = parse_eq(iter);


### PR DESCRIPTION
Started working on adding variable definitions via `let x = expr`.

Still some things to figure out:
Right now, it's possible to set variables to names which then are inaccessible because they are masked by a unit with the same name.
I'd like to probably change lookup slightly so it also returns the type of the lookup result, so before setting a variable, we can check whether there already is something other than a variable with this name and refuse. I think silently redefining variables with another `let` is fine, though.
Again, any thoughts or ideas are appreciated :)