### PR TITLE
Save history on error as well as success

### DIFF
--- a/src/repl.rs
+++ b/src/repl.rs
@@ -90,7 +90,10 @@ pub fn interactive(config: &Config) -> Result<()> {
                         rl.add_history_entry(line);
                         print_fmt(config, &v)
                     }
-                    Err(e) => print_fmt(config, &e),
+                    Err(e) => {
+                        rl.add_history_entry(line);
+                        print_fmt(config, &e)
+                    }
                 };
                 println!();
             }


### PR DESCRIPTION
Saving line history is important when there's a syntax error so you can recall the line to fix it.

I've tested this change and I much prefer it this way.