### PR TITLE
Add more tests

### DIFF
--- a/core/src/ast/def.rs
+++ b/core/src/ast/def.rs
@@ -20,7 +20,7 @@ pub enum DatePattern {
     Space,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 #[serde(into = "String", try_from = "String")]
 pub struct ExprString(pub Expr);
 
@@ -160,5 +160,47 @@ impl DatePattern {
             write!(buf, "{}", p).unwrap();
         }
         String::from_utf8(buf).unwrap()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{DatePattern, ExprString};
+    use crate::ast::Expr;
+    use std::convert::TryFrom;
+
+    #[test]
+    fn test_try_from() {
+        assert_eq!(
+            ExprString::try_from("abc".to_owned()),
+            Ok(ExprString(Expr::new_unit("abc".to_owned())))
+        );
+        assert_eq!(
+            ExprString::try_from("".to_owned()),
+            Ok(ExprString(Expr::new_error(
+                "Expected term, got eof".to_owned()
+            )))
+        );
+        assert_eq!(
+            ExprString::try_from("a -> ->".to_owned()),
+            Err("Expected EOF".to_owned())
+        )
+    }
+
+    #[test]
+    fn date_pattern_fmt() {
+        assert_eq!(format!("{}", DatePattern::Dash), "-");
+        assert_eq!(format!("{}", DatePattern::Colon), ":");
+        assert_eq!(format!("{}", DatePattern::Space), " ");
+        assert_eq!(format!("{}", DatePattern::Literal("a".to_owned())), "'a'");
+        assert_eq!(format!("{}", DatePattern::Match("a".to_owned())), "a");
+
+        assert_eq!(
+            format!(
+                "{}",
+                DatePattern::Optional(vec![DatePattern::Literal("a".to_owned())])
+            ),
+            "['a']"
+        );
     }
 }

--- a/core/src/ast/expr.rs
+++ b/core/src/ast/expr.rs
@@ -5,7 +5,7 @@
 use super::*;
 use serde_derive::Serialize;
 
-#[derive(Debug, Clone, Serialize)]
+#[derive(Debug, Clone, Serialize, PartialEq)]
 #[serde(rename_all = "lowercase")]
 #[serde(tag = "type")]
 pub enum Expr {
@@ -224,5 +224,28 @@ impl fmt::Display for Expr {
 impl From<i64> for Expr {
     fn from(x: i64) -> Self {
         Expr::new_const(x.into())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::parsing::text_query::{parse_expr, TokenIterator};
+
+    fn parse_then_pretty(input: &str) -> String {
+        let mut iter = TokenIterator::new(&input).peekable();
+        let expr = parse_expr(&mut iter);
+        expr.to_string()
+    }
+
+    #[test]
+    fn expr_display() {
+        assert_eq!(parse_then_pretty("meter"), "meter");
+        assert_eq!(parse_then_pretty("'hello world'"), "'hello world'");
+        assert_eq!(parse_then_pretty("234234"), "234234");
+        assert_eq!(parse_then_pretty("1 + 2"), "1 + 2");
+        assert_eq!(parse_then_pretty("speed of light"), "speed of light");
+        assert_eq!(parse_then_pretty("1 + 2 * 3"), "1 + 2 3");
+        assert_eq!(parse_then_pretty("(1 + 2) * 3"), "(1 + 2) 3");
+        assert_eq!(parse_then_pretty("a = 2"), "a = 2");
     }
 }

--- a/core/src/ast/mod.rs
+++ b/core/src/ast/mod.rs
@@ -29,7 +29,7 @@ pub enum Degree {
     Newton,
 }
 
-#[derive(Debug, Clone, Serialize)]
+#[derive(Debug, Clone, Serialize, PartialEq)]
 pub enum DateToken {
     Literal(String),
     Number(String, Option<String>),
@@ -62,7 +62,7 @@ impl BinOpType {
     }
 }
 
-#[derive(Debug, Clone, Serialize)]
+#[derive(Debug, Clone, Serialize, PartialEq)]
 pub struct BinOpExpr {
     pub op: BinOpType,
     pub left: Box<Expr>,
@@ -78,22 +78,13 @@ pub enum UnaryOpType {
     Degree(Degree),
 }
 
-impl UnaryOpType {
-    pub fn is_prefix(self) -> bool {
-        match self {
-            UnaryOpType::Degree(_) => false,
-            _ => true,
-        }
-    }
-}
-
-#[derive(Debug, Clone, Serialize)]
+#[derive(Debug, Clone, Serialize, PartialEq)]
 pub struct UnaryOpExpr {
     pub op: UnaryOpType,
     pub expr: Box<Expr>,
 }
 
-#[derive(Debug, Clone, Serialize)]
+#[derive(Debug, Clone, Copy, Serialize, PartialEq)]
 #[serde(rename_all = "camelCase")]
 pub enum Function {
     Sqrt,
@@ -210,5 +201,57 @@ impl fmt::Display for DateToken {
             DateToken::Plus => write!(fmt, "+"),
             DateToken::Error(ref e) => write!(fmt, "<{}>", e),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::ast::DateToken;
+
+    use super::Function;
+
+    const FUNCTIONS: &'static [Function] = &[
+        Function::Sqrt,
+        Function::Exp,
+        Function::Ln,
+        Function::Log2,
+        Function::Log10,
+        Function::Sin,
+        Function::Cos,
+        Function::Tan,
+        Function::Asin,
+        Function::Acos,
+        Function::Atan,
+        Function::Sinh,
+        Function::Cosh,
+        Function::Tanh,
+        Function::Asinh,
+        Function::Acosh,
+        Function::Atanh,
+        Function::Log,
+        Function::Hypot,
+        Function::Atan2,
+    ];
+
+    #[test]
+    fn roundtrip_function_names() {
+        for &func in FUNCTIONS {
+            assert_eq!(Function::from_name(func.name()), Some(func));
+        }
+    }
+
+    #[test]
+    fn date_tokens_display() {
+        assert_eq!(DateToken::Colon.to_string(), ":");
+        assert_eq!(DateToken::Dash.to_string(), "-");
+        assert_eq!(DateToken::Space.to_string(), " ");
+        assert_eq!(DateToken::Plus.to_string(), "+");
+        assert_eq!(DateToken::Literal("a".to_owned()).to_string(), "a");
+        assert_eq!(DateToken::Number("123".to_owned(), None).to_string(), "123");
+        assert_eq!(
+            DateToken::Number("123".to_owned(), Some("456".to_owned())).to_string(),
+            "123.456"
+        );
+        assert_eq!(DateToken::Error("test".to_owned()).to_string(), "<test>");
     }
 }

--- a/core/src/ast/query.rs
+++ b/core/src/ast/query.rs
@@ -47,3 +47,29 @@ impl fmt::Display for Conversion {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::Conversion;
+    use crate::ast::{Degree, Expr};
+    use chrono_tz::Tz;
+
+    #[test]
+    fn conversion_display() {
+        assert_eq!(Conversion::None.to_string(), "nothing");
+        assert_eq!(
+            Conversion::Expr(Expr::new_unit("a".to_owned())).to_string(),
+            "a"
+        );
+        assert_eq!(Conversion::Degree(Degree::Celsius).to_string(), "°C");
+        assert_eq!(
+            Conversion::List(vec!["a".to_owned(), "b".to_owned()]).to_string(),
+            "a, b"
+        );
+        assert_eq!(Conversion::Offset(3600 * 7).to_string(), "07:00");
+        assert_eq!(
+            Conversion::Timezone(Tz::US__Pacific).to_string(),
+            "US/Pacific"
+        );
+    }
+}

--- a/core/src/commands/factorize.rs
+++ b/core/src/commands/factorize.rs
@@ -7,18 +7,12 @@ use std::cmp;
 use std::collections::{BTreeMap, BinaryHeap};
 use std::rc::Rc;
 
-#[derive(PartialEq, Eq, Debug)]
+#[derive(PartialEq, Ord, Eq, Debug)]
 pub struct Factors(pub usize, pub Vec<Rc<String>>);
 
 impl cmp::PartialOrd for Factors {
     fn partial_cmp(&self, other: &Factors) -> Option<cmp::Ordering> {
         Some(self.0.cmp(&other.0))
-    }
-}
-
-impl cmp::Ord for Factors {
-    fn cmp(&self, other: &Factors) -> cmp::Ordering {
-        self.partial_cmp(other).unwrap()
     }
 }
 

--- a/core/src/loader/context.rs
+++ b/core/src/loader/context.rs
@@ -174,7 +174,7 @@ impl Context {
 
     pub fn humanize<Tz: chrono::TimeZone>(&self, date: chrono::DateTime<Tz>) -> Option<String> {
         if self.use_humanize {
-            crate::parsing::datetime::humanize(date)
+            crate::parsing::datetime::humanize(self.now, date)
         } else {
             None
         }

--- a/core/src/parsing/datetime.rs
+++ b/core/src/parsing/datetime.rs
@@ -493,10 +493,12 @@ pub fn parse_datefile(file: &str) -> Vec<Vec<DatePattern>> {
     defs
 }
 
-pub fn humanize<Tz: TimeZone>(date: DateTime<Tz>) -> Option<String> {
+pub fn humanize<Tz: TimeZone>(now: DateTime<Local>, date: DateTime<Tz>) -> Option<String> {
     if cfg!(feature = "chrono-humanize") {
         use chrono_humanize::HumanTime;
-        Some(HumanTime::from(date).to_string())
+        let now = now.with_timezone(&date.timezone());
+        let duration = date - now;
+        Some(HumanTime::from(duration).to_string())
     } else {
         None
     }

--- a/core/tests/query.rs
+++ b/core/tests/query.rs
@@ -2,13 +2,18 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
+use chrono::{Local, NaiveDate, TimeZone};
 use rink_core::parsing::text_query;
 use rink_core::Context;
 
 thread_local! {
     static CONTEXT: Context = {
         let mut ctx = rink_core::simple_context().unwrap();
-        ctx.use_humanize = false;
+        // Use a fixed time, this one is the timestamp of the first
+        // commit to Rink (in -04:00 originally, but use local time here
+        // for determinism.)
+        ctx.set_time(Local.from_local_datetime(&NaiveDate::from_ymd(2016, 8, 2).and_hms(15, 33, 19)).unwrap());
+        ctx.use_humanize = true;
         ctx
     };
 }
@@ -109,7 +114,7 @@ fn negative_prefixes() {
 fn negative_now() {
     test(
         "-#jan 01, 1970#",
-        "Operation is not defined: - <1970-01-01 00:00:00 +00:00>",
+        "Operation is not defined: - <1970-01-01 00:00:00 +00:00 (46 years ago)>",
     );
 }
 
@@ -168,7 +173,10 @@ fn test_conformance() {
 
 #[test]
 fn test_dates() {
-    test("#jan 01, 1970#", "1970-01-01 00:00:00 +00:00");
+    test(
+        "#jan 01, 1970#",
+        "1970-01-01 00:00:00 +00:00 (46 years ago)",
+    );
 }
 
 #[test]
@@ -191,7 +199,10 @@ fn test_volume_prefix() {
 
 #[test]
 fn test_offset_conversion() {
-    test("#jan 01, 1970# -> -05:00", "1969-12-31 19:00:00 -05:00");
+    test(
+        "#jan 01, 1970# -> -05:00",
+        "1969-12-31 19:00:00 -05:00 (46 years ago)",
+    );
 }
 
 #[test]
@@ -269,8 +280,14 @@ fn test_substance_add() {
 
 #[test]
 fn test_duration_add() {
-    test("#jan 01, 1970# + 1 s", "1970-01-01 00:00:01 +00:00");
-    test("#jan 01, 1970# + 1.123 s", "1970-01-01 00:00:01.123 +00:00");
+    test(
+        "#jan 01, 1970# + 1 s",
+        "1970-01-01 00:00:01 +00:00 (46 years ago)",
+    );
+    test(
+        "#jan 01, 1970# + 1.123 s",
+        "1970-01-01 00:00:01.123 +00:00 (46 years ago)",
+    );
 }
 
 #[test]
@@ -409,7 +426,7 @@ fn test_of_non_substance() {
 fn test_mul_not_defined() {
     test(
         "#2018-10-03# * kg",
-        "Operation is not defined: <1 (dimensionless)> * <2018-10-03 00:00:00 +00:00>",
+        "Operation is not defined: <1 (dimensionless)> * <2018-10-03 00:00:00 +00:00 (in 2 years)>",
     );
 }
 

--- a/core/tests/query.rs
+++ b/core/tests/query.rs
@@ -493,6 +493,7 @@ fn test_search() {
         "search cm",
         "Search results: cmil (area), cminv (energy), cmcapacitance (capacitance), sccm (power), mcm (area)",
     );
+    test("search water", "Search results: water (substance), waterton (volume), waterhorsepower (power), watt (power), watch (time)");
 }
 
 #[test]


### PR DESCRIPTION
Now that I have working code coverage I can start trying to get the code coverage percent back to where it was in the past.

I realized recently that chrono-humanize has an API that takes a duration instead of a straight date, allowing it to be deterministic, so I updated the tests with that.

## Local development with coverage

[Coverage Gutters VS code extension](https://marketplace.visualstudio.com/items?itemName=ryanluker.vscode-coverage-gutters) - set to watch mode.

`tasks.json`:
```json
{
  "label": "rust: cargo test (with coverage)",
  "isTestCommand": true,
  "type": "process",
  "command": "sh",
  "args": [".vscode/coverage.sh"],
  "problemMatcher": ["$rustc"]
}
```

`.vscode/coverage.sh`:
```sh
#!/bin/sh

export RUSTFLAGS="-C instrument-coverage"
export LLVM_PROFILE_FILE="$(pwd)/coverage/profraws/%p-%m.profraw"
export RUST_TOOLCHAIN="nightly"

mkdir -p coverage/profraws
rm coverage/profraws/*
cargo +nightly test --all
grcov coverage/profraws/* --binary-path ~/target/debug/ -t lcov -o coverage/lcov.info
echo 'Coverage information updated.'
```
