### PR TITLE
adjust croatian kuna after euro adoption

### DIFF
--- a/core/currency.units
+++ b/core/currency.units
@@ -99,8 +99,12 @@ krone                   NOK
 øre                     1|100 NOK
 
 # Croatia
-kuna                    HRK
-lipa                    1|100 HRK
+kuna                    croatiakuna
+lipa                    1|100 kuna
+dvakonja				20 kuna
+pebanki					50 kuna
+stoja					100 kuna
+dvistoje				200 kuna
 
 # Russia
 ₽                       RUB
@@ -259,6 +263,7 @@ cypruspound             1|0.585274 euro
 maltalira               1|0.429300 euro
 sloveniatolar           1|239.640 euro
 slovakiakoruna          1|30.1260 euro
+croatiakuna             1|7.53450 euro
 
 # Money on the gold standard, used in the late 19th century and early
 # 20th century.


### PR DESCRIPTION
Croatia adopted the euro on 2023-01-01, setting a fixed conversion rate of the kuna to euro to 7.53450 kuna per 1 euro. https://www.ecb.europa.eu/euro/changeover/croatia/html/index.en.html

The kuna is still often listed and used as a reference, so not removing it, but instead setting a fixed conversion rate and adding a couple of often used slang names for varied amounts.