### PR TITLE
Date range checking

### DIFF
--- a/core/src/parsing/datetime.rs
+++ b/core/src/parsing/datetime.rs
@@ -128,7 +128,7 @@ where
             "hour12" => match tok {
                 Some(DateToken::Number(ref s, None)) if s.len() == 2 => {
                     let value = u32::from_str_radix(&**s, 10).unwrap();
-                    if value < 12 {
+                    if value > 0 && value <= 12 {
                         out.hour_mod_12 = Some(value % 12);
                         Ok(())
                     } else {
@@ -143,9 +143,16 @@ where
             "hour24" => match tok {
                 Some(DateToken::Number(ref s, None)) if s.len() == 2 => {
                     let value = u32::from_str_radix(&**s, 10).unwrap();
-                    out.hour_div_12 = Some(value / 12);
-                    out.hour_mod_12 = Some(value % 12);
-                    Ok(())
+                    if value < 24 {
+                        out.hour_div_12 = Some(value / 12);
+                        out.hour_mod_12 = Some(value % 12);
+                        Ok(())
+                    } else {
+                        Err(format!(
+                            "Expected 2-digit hour24, got out of range value {}",
+                            s
+                        ))
+                    }
                 }
                 x => Err(format!("Expected 2-digit hour24, got {}", ts(x))),
             },

--- a/core/src/parsing/datetime.rs
+++ b/core/src/parsing/datetime.rs
@@ -177,8 +177,12 @@ where
             "sec" => match tok {
                 Some(DateToken::Number(ref s, None)) if s.len() == 2 => {
                     let value = u32::from_str_radix(&**s, 10).unwrap();
-                    out.second = Some(value);
-                    Ok(())
+                    if value <= 60 {
+                        out.second = Some(value);
+                        Ok(())
+                    } else {
+                        Err(format!("Expected 2-digit sec in range 0..=60, got {}", s))
+                    }
                 }
                 Some(DateToken::Number(ref s, Some(ref f))) if s.len() == 2 => {
                     let secs = u32::from_str_radix(&**s, 10).unwrap();

--- a/core/src/parsing/datetime.rs
+++ b/core/src/parsing/datetime.rs
@@ -128,8 +128,15 @@ where
             "hour12" => match tok {
                 Some(DateToken::Number(ref s, None)) if s.len() == 2 => {
                     let value = u32::from_str_radix(&**s, 10).unwrap();
-                    out.hour_mod_12 = Some(value % 12);
-                    Ok(())
+                    if value < 12 {
+                        out.hour_mod_12 = Some(value % 12);
+                        Ok(())
+                    } else {
+                        Err(format!(
+                            "Expected 2-digit hour12, got out of range value {}",
+                            s
+                        ))
+                    }
                 }
                 x => Err(format!("Expected 2-digit hour12, got {}", ts(x))),
             },

--- a/core/tests/query.rs
+++ b/core/tests/query.rs
@@ -550,6 +550,25 @@ fn test_to_timezone() {
 }
 
 #[test]
+fn test_time_range_checking() {
+    test("#00:00#", "2016-08-02 00:00:00 +00:00 (a day ago)");
+    test("#23:59#", "2016-08-02 23:59:00 +00:00 (in an hour)");
+    test("#12:00 am#", "2016-08-02 00:00:00 +00:00 (a day ago)");
+    test("#12:00 pm#", "2016-08-02 12:00:00 +00:00 (10 hours ago)");
+    test("#24:00#", "Most likely pattern `year-monthnum-fullday['T'hour24:min[:sec][ offset]]` failed: Expected `-`, got `:`");
+    test(
+        "#00:00 pm",
+        "Most likely pattern `hour24:min[:sec][ offset]` failed: Expected eof, got  pm",
+    );
+    test(
+        "#13:00 am#",
+        "Most likely pattern `hour24:min[:sec][ offset]` failed: Expected eof, got  am",
+    );
+    test("#0000-00-00#", "Most likely pattern `year-monthnum-fullday['T'hour24:min[:sec][ offset]]` failed: Expected monthnum in range 1..=12, got 00");
+    test("#0000-01-00#", "Most likely pattern `year-monthnum-fullday['T'hour24:min[:sec][ offset]]` failed: Expected fullday in range 1..=31, got 00");
+}
+
+#[test]
 fn test_gb_is_gigabytes() {
     test(
         "56kbps * 1 year -> GB",

--- a/core/tests/query.rs
+++ b/core/tests/query.rs
@@ -571,6 +571,8 @@ fn test_time_range_checking() {
         "#00:00:61#",
         "Most likely pattern `hour24:min[:sec][ offset]` failed: Expected eof, got :61",
     );
+    // used to panic
+    test("#99999999999999#", "Most likely pattern `year-monthnum-fullday['T'hour24:min[:sec][ offset]]` failed: Expected year, got out of range value");
 }
 
 #[test]

--- a/core/tests/query.rs
+++ b/core/tests/query.rs
@@ -566,6 +566,11 @@ fn test_time_range_checking() {
     );
     test("#0000-00-00#", "Most likely pattern `year-monthnum-fullday['T'hour24:min[:sec][ offset]]` failed: Expected monthnum in range 1..=12, got 00");
     test("#0000-01-00#", "Most likely pattern `year-monthnum-fullday['T'hour24:min[:sec][ offset]]` failed: Expected fullday in range 1..=31, got 00");
+    test("#00:00:00#", "2016-08-02 00:00:00 +00:00 (a day ago)");
+    test(
+        "#00:00:61#",
+        "Most likely pattern `hour24:min[:sec][ offset]` failed: Expected eof, got :61",
+    );
 }
 
 #[test]

--- a/core/tests/query.rs
+++ b/core/tests/query.rs
@@ -2,7 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-use chrono::{Local, NaiveDate, TimeZone};
+use chrono::{FixedOffset, TimeZone};
 use rink_core::parsing::text_query;
 use rink_core::Context;
 
@@ -12,7 +12,8 @@ thread_local! {
         // Use a fixed time, this one is the timestamp of the first
         // commit to Rink (in -04:00 originally, but use local time here
         // for determinism.)
-        ctx.set_time(Local.from_local_datetime(&NaiveDate::from_ymd_opt(2016, 8, 2).unwrap().and_hms_opt(15, 33, 19).unwrap()).unwrap());
+        let date = FixedOffset::east_opt(-4*60*60).unwrap().with_ymd_and_hms(2016, 8, 2, 15, 33, 19).unwrap();
+        ctx.set_time(date.into());
         ctx.use_humanize = true;
         ctx
     };
@@ -551,10 +552,10 @@ fn test_to_timezone() {
 
 #[test]
 fn test_time_range_checking() {
-    test("#00:00#", "2016-08-02 00:00:00 +00:00 (a day ago)");
-    test("#23:59#", "2016-08-02 23:59:00 +00:00 (in an hour)");
-    test("#12:00 am#", "2016-08-02 00:00:00 +00:00 (a day ago)");
-    test("#12:00 pm#", "2016-08-02 12:00:00 +00:00 (10 hours ago)");
+    test("#00:00#", "2016-08-02 00:00:00 +00:00 (19 hours ago)");
+    test("#23:59#", "2016-08-02 23:59:00 +00:00 (in 4 hours)");
+    test("#12:00 am#", "2016-08-02 00:00:00 +00:00 (19 hours ago)");
+    test("#12:00 pm#", "2016-08-02 12:00:00 +00:00 (7 hours ago)");
     test("#24:00#", "Most likely pattern `year-monthnum-fullday['T'hour24:min[:sec][ offset]]` failed: Expected `-`, got `:`");
     test(
         "#00:00 pm",
@@ -566,7 +567,7 @@ fn test_time_range_checking() {
     );
     test("#0000-00-00#", "Most likely pattern `year-monthnum-fullday['T'hour24:min[:sec][ offset]]` failed: Expected monthnum in range 1..=12, got 00");
     test("#0000-01-00#", "Most likely pattern `year-monthnum-fullday['T'hour24:min[:sec][ offset]]` failed: Expected fullday in range 1..=31, got 00");
-    test("#00:00:00#", "2016-08-02 00:00:00 +00:00 (a day ago)");
+    test("#00:00:00#", "2016-08-02 00:00:00 +00:00 (19 hours ago)");
     test(
         "#00:00:61#",
         "Most likely pattern `hour24:min[:sec][ offset]` failed: Expected eof, got :61",


### PR DESCRIPTION
Dates have no range checking which makes parsing them slightly unreliable and causes weird error messages like this:

```
> #25:00#
Most likely pattern `hour12:min[:sec] meridiem[ offset]` failed: Expected ` `, got eof
```

Additionally, large numbers cause a panic:
```
> #9999999999#
Panic: The application panicked (crashed).
Message:  called `Result::unwrap()` on an `Err` value: ParseIntError { kind: PosOverflow }
Location: core/src/parsing/datetime.rs:117

Backtrace omitted.
Run with RUST_BACKTRACE=1 environment variable to display it.
Run with RUST_BACKTRACE=full to include source snippets.
```

This PR adds range checks. I also cleaned up the code a little.