### PR TITLE
Custom definitions files

### DIFF
--- a/docs/rink-dates.5.adoc
+++ b/docs/rink-dates.5.adoc
@@ -111,7 +111,7 @@ Files
 
 Rink searches the following locations:
 
-* `./rink/datepatterns.txt`
+* `./datepatterns.txt`
 * `__$XDG_CONFIG_DIR__/rink/datepatterns.txt`
 * `/usr/share/rink/datepatterns.txt`
 

--- a/docs/rink-defs.5.adoc
+++ b/docs/rink-defs.5.adoc
@@ -248,16 +248,20 @@ decimal point.
 Files
 -----
 
-Rink searches for the definitions file in these locations:
+Rink searches for definitions files in these locations:
 
-* `./rink/definitions.units`
+* `./definitions.units`
 * `$XDG_CONFIG_DIR/rink/definitions.units`
 * `/usr/share/rink/definitions.units`
+
+It will load all of the files it finds. The files can reference
+definitions from each other. This can be used for custom definitions
+building on top of the default units database.
 
 When live currency fetching is enabled, Rink also looks for a currency
 file in these locations:
 
-* `./rink/currency.units`
+* `./currency.units`
 * `$XDG_CONFIG_DIR/rink/currency.units`
 * `/usr/share/rink/currency.units`
 


### PR DESCRIPTION
Implements #79.

The CLI will now load more than the first `definitions.units` file it finds. It will stick them together and load them as one big `definitions.units` file. This lets you easily add custom definitions by adding them to `~/.config/rink/definitions.units`. The format for it is already documented in the manpage.