### PR TITLE
Output bytes by default

### DIFF
--- a/core/src/types/number.rs
+++ b/core/src/types/number.rs
@@ -290,12 +290,13 @@ impl Number {
             .iter()
             .cloned()
             .collect::<HashSet<&'static str>>();
-            // kg special case
-            let (val, orig) = if &**(orig.0).id == "kg" || &**(orig.0).id == "kilogram" {
-                (
-                    &self.value * &Numeric::from(1000).pow(orig.1 as i32),
-                    (BaseUnit::new("gram"), orig.1),
-                )
+            let (val, orig) = if *orig.0.id == "kg" || *orig.0.id == "kilogram" {
+                // kg special case
+                let mul = Numeric::from(1000).pow(orig.1 as i32);
+                (&self.value * &mul, (BaseUnit::new("gram"), orig.1))
+            } else if *orig.0.id == "bit" && orig.1 == 1 {
+                // byte special case
+                (&self.value / &Numeric::from(8), (BaseUnit::new("byte"), 1))
             } else {
                 (self.value.clone(), (orig.0.clone(), orig.1))
             };

--- a/core/tests/query.rs
+++ b/core/tests/query.rs
@@ -797,3 +797,12 @@ fn test_extra_operators() {
         "Arguments to `xor` must be dimensionless: <1 meter (length)> xor <1 meter (length)>",
     );
 }
+
+#[test]
+fn test_bytes() {
+    test("1 mebibyte", "1.048576 megabyte (information)");
+    test("1 GiB", "approx. 1.073741 gigabyte (information)");
+    test("128 bit", "16 byte (information)");
+    test("100 byte^2", "6400 bit^2 (bit^2)");
+    test("1/byte", "0.125 / bit (bit^-1)");
+}


### PR DESCRIPTION
This has been annoying me for years. Make rink output bytes by default, even though bits are the base unit of information.

Only applies when you specifically ask for bytes by itself. Falls back to bits if you use some other unit like `bit s^-1`, `bit^2`, `bit^-1`, etc.

```
> 500 floppy
737.28 megabyte (information)
```

Improves #56 but doesn't really fix it.