### PR TITLE
Add more number output formats

### DIFF
--- a/core/src/output/numeric_parts.rs
+++ b/core/src/output/numeric_parts.rs
@@ -10,6 +10,7 @@ pub enum Digits {
     Digits(u64),
     Fraction,
     Scientific,
+    Engineering,
 }
 
 #[derive(Debug, Clone, Serialize)]

--- a/core/src/output/numeric_parts.rs
+++ b/core/src/output/numeric_parts.rs
@@ -8,6 +8,8 @@ pub enum Digits {
     Default,
     FullInt,
     Digits(u64),
+    Fraction,
+    Scientific,
 }
 
 #[derive(Debug, Clone, Serialize)]

--- a/core/src/parsing/text_query.rs
+++ b/core/src/parsing/text_query.rs
@@ -844,6 +844,10 @@ pub fn parse_query(iter: &mut Iter<'_>) -> Query {
                     iter.next();
                     Digits::Scientific
                 }
+                Token::Ident(ref s) if s == "eng" || s == "engineering" => {
+                    iter.next();
+                    Digits::Engineering
+                }
                 _ => Digits::Default,
             };
             let base = match iter.peek().cloned().unwrap() {

--- a/core/src/parsing/text_query.rs
+++ b/core/src/parsing/text_query.rs
@@ -836,7 +836,7 @@ pub fn parse_query(iter: &mut Iter<'_>) -> Query {
                         _ => Digits::FullInt,
                     }
                 }
-                Token::Ident(ref s) if s == "frac" || s == "fraction" => {
+                Token::Ident(ref s) if s == "frac" || s == "fraction" || s == "ratio" => {
                     iter.next();
                     Digits::Fraction
                 }

--- a/core/src/parsing/text_query.rs
+++ b/core/src/parsing/text_query.rs
@@ -836,6 +836,14 @@ pub fn parse_query(iter: &mut Iter<'_>) -> Query {
                         _ => Digits::FullInt,
                     }
                 }
+                Token::Ident(ref s) if s == "frac" || s == "fraction" => {
+                    iter.next();
+                    Digits::Fraction
+                }
+                Token::Ident(ref s) if s == "sci" || s == "scientific" => {
+                    iter.next();
+                    Digits::Scientific
+                }
                 _ => Digits::Default,
             };
             let base = match iter.peek().cloned().unwrap() {

--- a/core/src/runtime/eval.rs
+++ b/core/src/runtime/eval.rs
@@ -860,10 +860,16 @@ pub(crate) fn eval_query(ctx: &Context, expr: &Query) -> Result<QueryReply, Quer
                 value: parts,
             })))
         }
-        Query::Convert(ref top, Conversion::None, base, digits @ Digits::Digits(_))
-        | Query::Convert(ref top, Conversion::None, base, digits @ Digits::FullInt)
-        | Query::Convert(ref top, Conversion::None, base, digits @ Digits::Fraction)
-        | Query::Convert(ref top, Conversion::None, base, digits @ Digits::Scientific) => {
+        Query::Convert(
+            ref top,
+            Conversion::None,
+            base,
+            digits @ Digits::Digits(_)
+            | digits @ Digits::FullInt
+            | digits @ Digits::Fraction
+            | digits @ Digits::Scientific
+            | digits @ Digits::Engineering,
+        ) => {
             let top = eval_expr(ctx, top)?;
             let top = match top {
                 Value::Number(top) => top,
@@ -877,6 +883,7 @@ pub(crate) fn eval_query(ctx: &Context, expr: &Query) -> Result<QueryReply, Quer
                             Digits::Digits(n) => format!("{} digits", n),
                             Digits::Fraction => "fraction".to_owned(),
                             Digits::Scientific => "scientific".to_owned(),
+                            Digits::Engineering => "engineering".to_owned(),
                         }
                     )))
                 }
@@ -1058,7 +1065,7 @@ pub(crate) fn eval_query(ctx: &Context, expr: &Query) -> Result<QueryReply, Quer
             ref _expr,
             ref which,
             _base,
-            Digits::FullInt | Digits::Fraction | Digits::Scientific,
+            Digits::FullInt | Digits::Fraction | Digits::Scientific | Digits::Engineering,
         ) => Err(QueryError::generic(format!(
             "Conversion to digits of {} is not defined",
             which

--- a/core/src/types/bigrat.rs
+++ b/core/src/types/bigrat.rs
@@ -123,7 +123,7 @@ impl BigRat {
             let exact = cursor == zero;
             let placed_ints = n >= intdigits;
             let ndigits = match digits {
-                Digits::Default | Digits::Scientific => 6,
+                Digits::Default | Digits::Scientific | Digits::Engineering => 6,
                 Digits::FullInt | Digits::Fraction => 1000,
                 Digits::Digits(n) => intdigits as i32 + n as i32,
             };
@@ -221,11 +221,22 @@ impl BigRat {
             self * &BigRat::ratio(&absexp, &BigInt::one())
         };
         let ten = BigRat::small_ratio(base as i64, 1);
-        let (rational, intdigits) = if rational.abs() == ten {
+        let (mut rational, mut intdigits) = if rational.abs() == ten {
             (&rational / &ten, intdigits + 1)
         } else {
             (rational, intdigits)
         };
+
+        if digits == Digits::Engineering {
+            let adjust = (intdigits % 3 + 3) % 3;
+            rational = &rational
+                * &BigRat::ratio(
+                    &BigInt::from(base as i64).pow(adjust as u32),
+                    &BigInt::one(),
+                );
+            intdigits -= adjust;
+        }
+
         let (is_exact, mut result) = rational.to_digits_impl(base, digits);
         if !result.contains('.') {
             result.push('.');
@@ -248,7 +259,8 @@ impl BigRat {
         let abs = self.abs();
         let is_computer_base = base == 2 || base == 8 || base == 16 || base == 32;
         let is_computer_integer = is_computer_base && self.denom() == BigInt::one();
-        let can_use_sci = digits == Digits::Default && !is_computer_integer;
+        let can_use_sci =
+            (digits == Digits::Default || digits == Digits::Engineering) && !is_computer_integer;
         let in_range_for_sci = &abs >= &BigRat::small_ratio(1_000_000_000, 1)
             || &abs <= &BigRat::small_ratio(1, 1_000_000_000);
 

--- a/core/src/types/bigrat.rs
+++ b/core/src/types/bigrat.rs
@@ -123,8 +123,8 @@ impl BigRat {
             let exact = cursor == zero;
             let placed_ints = n >= intdigits;
             let ndigits = match digits {
-                Digits::Default => 6,
-                Digits::FullInt => 1000,
+                Digits::Default | Digits::Scientific => 6,
+                Digits::FullInt | Digits::Fraction => 1000,
                 Digits::Digits(n) => intdigits as i32 + n as i32,
             };
             // Conditions for exiting:
@@ -241,15 +241,18 @@ impl BigRat {
             return (true, "0".to_owned());
         }
 
+        if digits == Digits::Fraction {
+            return (true, format!("{}", self));
+        }
+
         let abs = self.abs();
         let is_computer_base = base == 2 || base == 8 || base == 16 || base == 32;
         let is_computer_integer = is_computer_base && self.denom() == BigInt::one();
         let can_use_sci = digits == Digits::Default && !is_computer_integer;
+        let in_range_for_sci = &abs >= &BigRat::small_ratio(1_000_000_000, 1)
+            || &abs <= &BigRat::small_ratio(1, 1_000_000_000);
 
-        if can_use_sci
-            && (&abs >= &BigRat::small_ratio(1_000_000_000, 1)
-                || &abs <= &BigRat::small_ratio(1, 1_000_000_000))
-        {
+        if digits == Digits::Scientific || can_use_sci && in_range_for_sci {
             self.to_scientific(base, digits)
         } else {
             self.to_digits_impl(base, digits)

--- a/core/src/types/number.rs
+++ b/core/src/types/number.rs
@@ -277,9 +277,18 @@ impl Number {
         }
     }
 
+    pub fn with_pretty_unit(&self, context: &Context) -> Number {
+        let unit = self.pretty_unit(context);
+        Number {
+            value: self.value.clone(),
+            unit,
+        }
+    }
+
     /// Convert the units of the number from base units to display
     /// units, and possibly apply SI prefixes.
     pub fn prettify(&self, context: &Context) -> Number {
+        println!("{:?}", self);
         let unit = self.pretty_unit(context);
         if let Some(orig) = unit.as_single() {
             use std::collections::HashSet;
@@ -316,12 +325,15 @@ impl Number {
                         format!("{}{}", p, orig.0)
                     };
                     let unit = Dimensionality::new_dim(BaseUnit::new(&unit), orig.1);
+                    println!("using prefix {p}: {res:?} {unit:?}");
                     return Number { value: res, unit };
                 }
             }
             let unit = Dimensionality::new_dim(orig.0.clone(), orig.1);
+            println!("no prefix: {val:?} {unit:?}");
             Number { value: val, unit }
         } else {
+            println!("else case: {:?} {unit:?}", self.value);
             Number {
                 value: self.value.clone(),
                 unit,
@@ -330,8 +342,16 @@ impl Number {
     }
 
     pub fn to_parts(&self, context: &Context) -> NumberParts {
-        let value = self.prettify(context);
-        let (exact, approx) = value.numeric_value(10, Digits::Default);
+        self.to_parts_digits(context, 10, Digits::Default)
+    }
+
+    pub fn to_parts_digits(&self, context: &Context, base: u8, digits: Digits) -> NumberParts {
+        let value = if digits == Digits::Default {
+            self.prettify(context)
+        } else {
+            self.with_pretty_unit(context)
+        };
+        let (exact, approx) = value.numeric_value(base, digits);
 
         let quantity = context
             .registry

--- a/core/src/types/number.rs
+++ b/core/src/types/number.rs
@@ -288,7 +288,6 @@ impl Number {
     /// Convert the units of the number from base units to display
     /// units, and possibly apply SI prefixes.
     pub fn prettify(&self, context: &Context) -> Number {
-        println!("{:?}", self);
         let unit = self.pretty_unit(context);
         if let Some(orig) = unit.as_single() {
             use std::collections::HashSet;
@@ -325,15 +324,12 @@ impl Number {
                         format!("{}{}", p, orig.0)
                     };
                     let unit = Dimensionality::new_dim(BaseUnit::new(&unit), orig.1);
-                    println!("using prefix {p}: {res:?} {unit:?}");
                     return Number { value: res, unit };
                 }
             }
             let unit = Dimensionality::new_dim(orig.0.clone(), orig.1);
-            println!("no prefix: {val:?} {unit:?}");
             Number { value: val, unit }
         } else {
-            println!("else case: {:?} {unit:?}", self.value);
             Number {
                 value: self.value.clone(),
                 unit,

--- a/core/tests/query.rs
+++ b/core/tests/query.rs
@@ -817,5 +817,24 @@ fn test_output_formats() {
     test("1 to frac", "1 (dimensionless)");
     test("1 to sci", "1.0e0 (dimensionless)");
     test("1/7 to frac", "1/7 (dimensionless)");
-    test("1/7 to sci", "1.[428571]...e-1");
+    test("1/7 to sci", "1.[428571]...e-1 (dimensionless)");
+
+    // engineering
+    test("1e9 to eng", "1.0e9 (dimensionless)");
+    test("1e10 to eng", "10.0e9 (dimensionless)");
+    test("1e11 to eng", "100.0e9 (dimensionless)");
+    test("1e12 to eng", "1.0e12 (dimensionless)");
+    test("1e13 to eng", "10.0e12 (dimensionless)");
+    test("1e14 to eng", "100.0e12 (dimensionless)");
+    test("1e15 to eng", "1.0e15 (dimensionless)");
+    test("1e16 to eng", "10.0e15 (dimensionless)");
+    test("1e17 to eng", "100.0e15 (dimensionless)");
+
+    test("1e-9 to eng", "1.0e-9 (dimensionless)");
+    test("1e-10 to eng", "100.0e-12 (dimensionless)");
+    test("1e-11 to eng", "10.0e-12 (dimensionless)");
+    test("1e-12 to eng", "1.0e-12 (dimensionless)");
+    test("1e-13 to eng", "100.0e-15 (dimensionless)");
+    test("1e-14 to eng", "10.0e-15 (dimensionless)");
+    test("1e-15 to eng", "1.0e-15 (dimensionless)");
 }

--- a/core/tests/query.rs
+++ b/core/tests/query.rs
@@ -817,7 +817,12 @@ fn test_output_formats() {
     test("1 to frac", "1 (dimensionless)");
     test("1 to sci", "1.0e0 (dimensionless)");
     test("1/7 to frac", "1/7 (dimensionless)");
+    test("1/7 to fraction", "1/7 (dimensionless)");
+    test("1/7 to ratio", "1/7 (dimensionless)");
     test("1/7 to sci", "1.[428571]...e-1 (dimensionless)");
+    test("1/7 to scientific", "1.[428571]...e-1 (dimensionless)");
+    test("0.5 to eng", "0.5 (dimensionless)");
+    test("0.5 to engineering", "0.5 (dimensionless)");
 
     // engineering
     test("1e9 to eng", "1.0e9 (dimensionless)");
@@ -841,10 +846,28 @@ fn test_output_formats() {
 
 #[test]
 fn conversion_to_digit_errors() {
-    test("egg to digits", "<1 (dimensionless) egg> to digits is not defined");
-    test("egg to digits 50", "<1 (dimensionless) egg> to 50 digits is not defined");
-    test("egg to frac", "<1 (dimensionless) egg> to fraction is not defined");
-    test("egg to sci", "<1 (dimensionless) egg> to scientific is not defined");
-    test("egg to eng", "<1 (dimensionless) egg> to engineering is not defined");
-    test("now to digits \"US/Pacific\"", "Conversion to digits of US/Pacific is not defined");
+    test(
+        "egg to digits",
+        "<1 (dimensionless) egg> to digits is not defined",
+    );
+    test(
+        "egg to digits 50",
+        "<1 (dimensionless) egg> to 50 digits is not defined",
+    );
+    test(
+        "egg to frac",
+        "<1 (dimensionless) egg> to fraction is not defined",
+    );
+    test(
+        "egg to sci",
+        "<1 (dimensionless) egg> to scientific is not defined",
+    );
+    test(
+        "egg to eng",
+        "<1 (dimensionless) egg> to engineering is not defined",
+    );
+    test(
+        "now to digits \"US/Pacific\"",
+        "Conversion to digits of US/Pacific is not defined",
+    );
 }

--- a/core/tests/query.rs
+++ b/core/tests/query.rs
@@ -806,3 +806,16 @@ fn test_bytes() {
     test("100 byte^2", "6400 bit^2 (bit^2)");
     test("1/byte", "0.125 / bit (bit^-1)");
 }
+
+#[test]
+fn test_output_formats() {
+    test("surveyfoot to digits", "0.[304800609601219202438404876809753619507239014478028956057912115824231648463296926593853187706375412750825501651003302006604013208026416052832105664211328422656845313690627381254762509525019050038100076200152400, period 210]... meter (length)");
+    test("surveyfoot to frac", "1200/3937 meter (length)");
+    test("surveyfoot to sci", "approx. 3.048006e-1 meter (length)");
+    test("foot to frac", "381/1250 meter (length)");
+    test("foot to sci", "3.048e-1 meter (length)");
+    test("1 to frac", "1 (dimensionless)");
+    test("1 to sci", "1.0e0 (dimensionless)");
+    test("1/7 to frac", "1/7 (dimensionless)");
+    test("1/7 to sci", "1.[428571]...e-1");
+}

--- a/core/tests/query.rs
+++ b/core/tests/query.rs
@@ -838,3 +838,13 @@ fn test_output_formats() {
     test("1e-14 to eng", "10.0e-15 (dimensionless)");
     test("1e-15 to eng", "1.0e-15 (dimensionless)");
 }
+
+#[test]
+fn conversion_to_digit_errors() {
+    test("egg to digits", "<1 (dimensionless) egg> to digits is not defined");
+    test("egg to digits 50", "<1 (dimensionless) egg> to 50 digits is not defined");
+    test("egg to frac", "<1 (dimensionless) egg> to fraction is not defined");
+    test("egg to sci", "<1 (dimensionless) egg> to scientific is not defined");
+    test("egg to eng", "<1 (dimensionless) egg> to engineering is not defined");
+    test("now to digits \"US/Pacific\"", "Conversion to digits of US/Pacific is not defined");
+}

--- a/docs/rink.7.adoc
+++ b/docs/rink.7.adoc
@@ -372,8 +372,8 @@ recognized:
 `bin`, `binary`, `base2`::
 	Base 2.
 
-Digits modifier
-^^^^^^^^^^^^^^^
+Number representation modifiers
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 	> 2^128 -> digits
 	340282366920938463463374607431768211456 (dimensionless)
@@ -381,6 +381,10 @@ Digits modifier
 	0.[000254000508001016002032004064008128016256032512065024130048260096520193040386080772161544323088646177292354584709169418338836677673355346710693421386842773685547371094742189484378968757937515875031750063500127, period 210]...  (dimensionless)
 	> googol -> digits
 	10000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000 (dimensionless)
+	> mass of electron -> eng
+	approx. 910.9383e-33 kilogram (mass)
+	> 3 foot -> frac
+	1143/1250 meter (length)
 
 Digits modifiers are specified with `digits` optionally followed by a
 number, before the base modifier and before the rest of the
@@ -402,6 +406,16 @@ Trigonometric and logarithmic functions are currently implemented
 using a machine-float fallback, because their results cannot be
 precisely represented as finite rationals. Because of this, asking for
 many digits of such numbers will also produce unsatisfying results.
+
+`frac`, `fraction`, `ratio` are all equivalent. They will print
+the rational fraction that Rink internally represents the number using.
+
+`sci`, `scientific` will force the use of scientific notation, even for
+small numbers.
+
+`eng`, `engineering` are similar to the default format, where it uses
+scientific notation only for large numbers. However, when it does use
+scientific notation, it rounds down to every third power.
 
 Units for
 ^^^^^^^^^


### PR DESCRIPTION
Adds `to frac` and `to sci` to explicitly force the use of these representations. Also adds `to eng` which behaves similar to the default behavior, except rounds to every third power of 10 instead of every power of 10. I might make the output format configurable and set the engineering one as the default in a future version.

While working on this I found a bug in the current version of rink. `surveyfoot to digits` is incorrect by 3 orders of magnitude. I fixed that in this PR.