### PR TITLE
Manually invoked currency refresh

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,5 @@
 **/.rpt2_cache
 **/build
 /web/data
+# created by unit tests
+/cli/currency.json

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -102,6 +102,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "23b62fc65de8e4e7f52534fb52b0f3ed04746ae267519eef2a83941e8085068b"
 
 [[package]]
+name = "ascii"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d92bec98840b8f03a5ff5413de5293bfcd8bf96467cf5452609f939ec6f5de16"
+
+[[package]]
 name = "assert-json-diff"
 version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -478,6 +484,12 @@ dependencies = [
  "chrono",
  "parse-zoneinfo",
 ]
+
+[[package]]
+name = "chunked_transfer"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e4de3bc4ea267985becf712dc6d9eed8b04c953b3fcfb339ebc87acd9804901"
 
 [[package]]
 name = "clap"
@@ -1084,6 +1096,12 @@ name = "hermit-abi"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d231dfb89cfffdbc30e7fc41579ed6066ad03abda9e567ccafae602b97ec5024"
+
+[[package]]
+name = "httpdate"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
 name = "humantime"
@@ -1751,6 +1769,7 @@ dependencies = [
  "serde_json",
  "similar-asserts",
  "tempfile",
+ "tiny_http",
  "toml 0.5.11",
  "ubyte",
 ]
@@ -2147,6 +2166,18 @@ checksum = "8b9ef9bad013ada3808854ceac7b46812a6465ba368859a37e2100283d2d719c"
 dependencies = [
  "cfg-if 1.0.0",
  "once_cell",
+]
+
+[[package]]
+name = "tiny_http"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "389915df6413a2e74fb181895f933386023c71110878cd0825588928e64cdc82"
+dependencies = [
+ "ascii",
+ "chunked_transfer",
+ "httpdate",
+ "log",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1761,6 +1761,7 @@ dependencies = [
  "eyre",
  "humantime-serde",
  "nu-ansi-term",
+ "once_cell",
  "rink-core",
  "rink-sandbox",
  "rustyline",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -42,6 +42,7 @@ path = "../sandbox"
 
 [dev-dependencies]
 similar-asserts = "1.1.0"
+tiny_http = "0.12"
 
 [package.metadata.wasm-pack.profile.profiling]
 wasm-opt = ['-g', '-O']

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -43,6 +43,7 @@ path = "../sandbox"
 [dev-dependencies]
 similar-asserts = "1.1.0"
 tiny_http = "0.12"
+once_cell = "1"
 
 [package.metadata.wasm-pack.profile.profiling]
 wasm-opt = ['-g', '-O']

--- a/cli/src/config.rs
+++ b/cli/src/config.rs
@@ -266,7 +266,8 @@ pub(crate) fn force_refresh_currency(config: &Currency) -> Result<String> {
     let mut path = dirs::cache_dir().ok_or_else(|| eyre!("Could not find cache directory"))?;
     path.push("rink");
     path.push("currency.json");
-    let file = download_to_file(&path, &config.endpoint, config.timeout).wrap_err("Fetching currency data failed")?;
+    let file = download_to_file(&path, &config.endpoint, config.timeout)
+        .wrap_err("Fetching currency data failed")?;
     let delta = std::time::Instant::now() - start;
     let metadata = file
         .metadata()

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -45,6 +45,12 @@ async fn main() -> Result<()> {
                 .action(ArgAction::SetTrue)
         )
         .arg(
+            Arg::new("fetch-currency")
+                .long("fetch-currency")
+                .help("Fetches latest version of currency data, then exits")
+                .action(ArgAction::SetTrue)
+        )
+        .arg(
             Arg::new("dump")
                 .long("dump")
                 .help("Generates a file containing the contents of the Context object, then exits")
@@ -76,6 +82,17 @@ async fn main() -> Result<()> {
         let mut file = std::fs::File::create(filename)?;
         writeln!(&mut file, "{:#?}", ctx)?;
         return Ok(());
+    }
+
+    if matches.get_flag("fetch-currency") {
+        let result = config::force_refresh_currency(&config.currency);
+        match result {
+            Ok(msg) => {
+                println!("{msg}");
+                return Ok(());
+            }
+            Err(err) => return Err(err)
+        }
     }
 
     if matches.get_flag("config-path") {

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -91,7 +91,7 @@ async fn main() -> Result<()> {
                 println!("{msg}");
                 return Ok(());
             }
-            Err(err) => return Err(err)
+            Err(err) => return Err(err),
         }
     }
 

--- a/docs/rink.1.adoc
+++ b/docs/rink.1.adoc
@@ -63,6 +63,9 @@ Rink looks for a configuration file in
 Rink relies on some data files, which are found using a search path.
 See rink-defs(5) and rink-dates(5).
 
+Downloaded currency data is saved in
+`$XDG_CACHE_DIR/rink/currency.json`.
+
 Bugs
 ----
 

--- a/docs/rink.1.adoc
+++ b/docs/rink.1.adoc
@@ -25,6 +25,11 @@ Options
 **--config-path**::
 	Prints a path to the config file, then exits.
 
+**--fetch-currency**:
+	Fetches the latest version of the currency data, then exits. Can be
+	used as part of a cron job, possibly together with setting
+	`currency.fetch_on_startup` to false.
+
 **-f**::
 **--file** <__file__>::
 	Reads expressions from a file, one per line, printing them to stdout

--- a/docs/rink.5.adoc
+++ b/docs/rink.5.adoc
@@ -63,6 +63,14 @@ The `[currency]` section.
 	Currency fetching can be disabled for those that don't want it.
 	Default: `true`
 
+*fetch_on_startup* = <__bool__>::
+	Setting this to `false` causes rink to behave as if
+	`cache_duration` was infinite. If the currency file doesn't
+	exist, it will fetch it, otherwise it will use it indefinitely.
+	Rink can be invoked with `--fetch-currency` to download the
+	latest version.
+	Default: `true`
+
 *endpoint* = <__url__>::
 	Allows pointing to alternate Rink-Web instances, or to any other API
 	that offers a compatible format.


### PR DESCRIPTION
Adds `currency.fetch_on_startup` to the config, which when set to false behaves as if the `cache_duration` was infinite. This means rink will fetch the file once, and then keep reusing that file indefinitely.

Adds a `--fetch-currency` CLI argument, which will make rink download the latest version of the currency data and then exit. This can be put into a cron job and used together with the config option so that rink will never block on a web request at startup, without giving up currency units. Requires manual setup though.