### PR TITLE
feat(core): Add "relative dates"

### DIFF
--- a/core/datepatterns.txt
+++ b/core/datepatterns.txt
@@ -21,6 +21,7 @@ year monthname day[ hour12:min[:sec] meridiem[ offset]][ adbc]
 year monthname day[ hour24:min[:sec][ offset]][ adbc]
 
 # Relative dates
+today
 today:adddays
 today:-subdays
 [today[:[adddays][-subdays]]] hour12:min[:sec] meridiem[ offset]

--- a/core/datepatterns.txt
+++ b/core/datepatterns.txt
@@ -20,6 +20,13 @@ weekday monthname day[ hour24:min[:sec]] fullyear
 year monthname day[ hour12:min[:sec] meridiem[ offset]][ adbc]
 year monthname day[ hour24:min[:sec][ offset]][ adbc]
 
-# Today dates
-hour12:min[:sec] meridiem[ offset]
-hour24:min[:sec][ offset]
+# Relative dates
+today:adddays
+today:-subdays
+[today[:[adddays][-subdays]]] hour12:min[:sec] meridiem[ offset]
+[today[:[adddays][-subdays]]] hour24:min[:sec][ offset]
+
+today:'W'addweeks
+today:'W'subweeks
+[today[:'W'[addweeks][-subweeks]]] hour12:min[:sec] meridiem[ offset]
+[today[:'W'[addweeks][-subweeks]]] hour24:min[:sec][ offset]

--- a/core/datepatterns.txt
+++ b/core/datepatterns.txt
@@ -24,10 +24,14 @@ year monthname day[ hour24:min[:sec][ offset]][ adbc]
 today
 today:adddays
 today:-subdays
-[today[:[adddays][-subdays]]] hour12:min[:sec] meridiem[ offset]
-[today[:[adddays][-subdays]]] hour24:min[:sec][ offset]
+today[:[adddays][-subdays]] hour12:min[:sec] meridiem[ offset]
+today[:[adddays][-subdays]] hour24:min[:sec][ offset]
+hour12:min[:sec] meridiem[ offset]
+hour24:min[:sec][ offset]
 
 today:'W'addweeks
 today:'W'subweeks
-[today[:'W'[addweeks][-subweeks]]] hour12:min[:sec] meridiem[ offset]
-[today[:'W'[addweeks][-subweeks]]] hour24:min[:sec][ offset]
+today[:'W'[addweeks][-subweeks]] hour12:min[:sec] meridiem[ offset]
+today[:'W'[addweeks][-subweeks]] hour24:min[:sec][ offset]
+hour12:min[:sec] meridiem[ offset]
+hour24:min[:sec][ offset]

--- a/docs/rink-dates.5.adoc
+++ b/docs/rink-dates.5.adoc
@@ -104,7 +104,7 @@ The valid keywords are:
 
 **subdays**::
 	Matches a number of days. Can be any number of digits. Subtracts that
-	amount of days to the date relative to **today**.
+	amount of days from the date relative to **today**.
 
 **addweeks**::
 	Matches a number of weeks. Can be any number of digits. Adds that
@@ -112,7 +112,7 @@ The valid keywords are:
 
 **subweeks**::
 	Matches a number of weeks. Can be any number of digits. Subtracts that
-	amount of weeks to the date relative to **today**.
+	amount of weeks from the date relative to **today**.
 
 **`-`**::
 	Matches a literal `-` character.

--- a/docs/rink-dates.5.adoc
+++ b/docs/rink-dates.5.adoc
@@ -94,6 +94,26 @@ The valid keywords are:
 	Makes English weekday names, case insensitive. Recognizes 3-letter
 	names (like mon, tue, wed) and full names.
 
+**today**::
+	Specifies a relative date. Resets the date to the current date in the
+	local timezone, with time at 00:00.
+
+**adddays**::
+	Matches a number of days. Can be any number of digits. Adds that amount
+	of days to the date relative to **today**.
+
+**subdays**::
+	Matches a number of days. Can be any number of digits. Subtracts that
+	amount of days to the date relative to **today**.
+
+**addweeks**::
+	Matches a number of weeks. Can be any number of digits. Adds that
+	amount of weeks to the date relative to **today**.
+
+**subweeks**::
+	Matches a number of weeks. Can be any number of digits. Subtracts that
+	amount of weeks to the date relative to **today**.
+
 **`-`**::
 	Matches a literal `-` character.
 


### PR DESCRIPTION
I was looking at your project and really liked it, especially for some quick
date calculations, such as `#2023-05-03# - #2024-06-22# in months;weeks;days`
which turned out to be so simple to do compared to spinning up either a
spreadsheet, node.js, python etc. What I was missing though was, as you might've
guessed, a feature to specify relative dates such as `today:-1`... This way the
above calculation could've been just:
 `#2023-05-03# - #today# in months;weeks;days`! Hence this PR.

As for the code, it is a tad copy-pasty, but the MVP is there. I constrained it
to "just" weeks and days, as to keep it a bit more sane. I hope you like the
idea!
