### PR TITLE
[web] Use defer instead of async

### DIFF
--- a/web/plugins/vite.lua
+++ b/web/plugins/vite.lua
@@ -23,7 +23,7 @@ while files[i] do
 		local script = HTML.create_element("script")
 		HTML.set_attribute(script, "src", "/immutable/" .. file)
 		HTML.set_attribute(script, "data-wasm", "/" .. wasm_out)
-		HTML.set_attribute(script, "async", "")
+		HTML.set_attribute(script, "defer", "")
 		local head = HTML.select_one(page, "head")
 		HTML.append_child(head, script)
 	end


### PR DESCRIPTION
Sometimes the web repl will fail with this error message in the console:
```
Uncaught (in promise) TypeError: rinkDiv is null
    Immutable 2
        pushError
        <anonymous>
index.1d6d65d8.js:111:3
```
To reproduce in Firefox, ctrl+click on a link to `rinkcalc.app`, such as [this one](https://rinkcalc.app/?q=(c/sqrt(4.5))/2.4GHz/20).

Seems like it's caused by a race condition. The script is in the `<head>` element and is marked `async`. Async scripts apparently run in parallel to parsing the page. Changing this to `defer` fixes it for me.