### PR TITLE
Try replacing codecov

### DIFF
--- a/.github/workflows/coverage-pull.yml
+++ b/.github/workflows/coverage-pull.yml
@@ -1,8 +1,6 @@
 name: Code Coverage
 
 on:
-  push:
-    branches: [master]
   pull_request:
     branches: [master]
 

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -20,11 +20,13 @@ jobs:
         run: rustup update stable
       - name: Install cargo-llvm-cov
         uses: taiki-e/install-action@cargo-llvm-cov
-      - name: Generate code coverage
-        # rink-sandbox causes corrupted .profraw files for some reason,
-        # so don't test it. test everything else.
-        run: cargo llvm-cov --all-features -p rink-core -p rink -p rink-js --cobertura --output-path coverage.xml
-      - name: Code Coverage Summary Report
-        uses: irongut/CodeCoverageSummary@v1.3.0
+      - name: Install uv
+        uses: astral-sh/setup-uv@v6
+      - name: Generate coverage
+        run: make coverage
+      - name: Generate report
+        run: make coverage-report
+      - name: Create PR comment
+        uses: peter-evans/create-or-update-comment@v4.0.0
         with:
-          filename: coverage.xml
+          body-path: report.md

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -16,6 +16,8 @@ jobs:
       CARGO_TERM_COLOR: always
     steps:
       - uses: actions/checkout@v4
+      - name: Get master branch
+        run: git fetch origin master --depth 1
       - name: Install Rust
         run: rustup update stable
       - name: Install cargo-llvm-cov

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -16,6 +16,8 @@ jobs:
       CARGO_TERM_COLOR: always
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 50
       - name: Get master branch
         run: git fetch origin master --depth 1
       - name: Install Rust

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -23,8 +23,8 @@ jobs:
       - name: Generate code coverage
         # rink-sandbox causes corrupted .profraw files for some reason,
         # so don't test it. test everything else.
-        run: cargo llvm-cov --all-features -p rink-core -p rink -p rink-js --lcov --output-path lcov.info
+        run: cargo llvm-cov --all-features -p rink-core -p rink -p rink-js --cobertura --output-path coverage.xml
       - name: Code Coverage Summary Report
         uses: irongut/CodeCoverageSummary@v1.3.0
         with:
-          filename: lcov.info
+          filename: coverage.xml

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -24,9 +24,7 @@ jobs:
         # rink-sandbox causes corrupted .profraw files for some reason,
         # so don't test it. test everything else.
         run: cargo llvm-cov --all-features -p rink-core -p rink -p rink-js --lcov --output-path lcov.info
-      - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v5
+      - name: Code Coverage Summary Report
+        uses: irongut/CodeCoverageSummary@v1.3.0
         with:
-          token: ${{ secrets.CODECOV_TOKEN }}
-          files: lcov.info
-          fail_ci_if_error: true
+          filename: lcov.info

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -30,7 +30,16 @@ jobs:
         run: make coverage
       - name: Generate report
         run: make coverage-report
+      - name: Find Comment
+        uses: peter-evans/find-comment@v3
+        id: fc
+        with:
+          issue-number: ${{ github.event.pull_request.number }}
+          comment-author: 'github-actions[bot]'
+          body-includes: Diff Coverage
       - name: Create PR comment
         uses: peter-evans/create-or-update-comment@v4.0.0
         with:
+          comment-id: ${{ steps.fc.outputs.comment-id }}
+          issue-number: ${{ github.event.pull_request.number }}
           body-path: report.md

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -43,3 +43,4 @@ jobs:
           comment-id: ${{ steps.fc.outputs.comment-id }}
           issue-number: ${{ github.event.pull_request.number }}
           body-path: report.md
+          edit-mode: replace

--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,5 @@
 /web/data
 # created by unit tests
 /cli/currency.json
+report.md
+lcov.info

--- a/Makefile
+++ b/Makefile
@@ -64,3 +64,9 @@ installfiles:
 	$(INSTALL) -m 0644 $(srcdir)/core/currency.units $(datadir)/rink/currency.units
 
 install: installbin installman installfiles
+
+coverage:
+	$(CARGO) llvm-cov --all --lcov --output-path lcov.info
+
+coverage-report:
+	uv tool run diff-cover lcov.info --format markdown:report.md --compare-branch origin/master

--- a/Makefile
+++ b/Makefile
@@ -72,6 +72,6 @@ coverage-report:
 	uv tool run diff-cover lcov.info --format markdown:report.md --compare-branch origin/master
 	$(CARGO) llvm-cov report --html
 	echo '<details><summary>Full report</summary>' >> report.md
-	grep -Go "<table>.*</table>" target/llvm-cov/html/index.html | sed -Ee 's|<(/{0,1})pre>|<\1code>|g' >> report.md
+	grep -Go "<table>.*</table>" target/llvm-cov/html/index.html | sed -Ee 's|\s*<(/{0,1})pre>\s*|<\1code>|g' >> report.md
 	echo '</details>' >> report.md
 

--- a/Makefile
+++ b/Makefile
@@ -69,4 +69,9 @@ coverage:
 	$(CARGO) llvm-cov --all --lcov --output-path lcov.info
 
 coverage-report:
-	uv tool run diff-cover lcov.info --format markdown:report.md --compare-branch master
+	uv tool run diff-cover lcov.info --format markdown:report.md --compare-branch origin/master
+	$(CARGO) llvm-cov report --html
+	echo '<details summary="Full report">' >> report.md
+	grep -Go "<table>.*</table>" target/llvm-cov/html/index.html >> report.md
+	echo '</details>' >> report.md
+

--- a/Makefile
+++ b/Makefile
@@ -71,7 +71,7 @@ coverage:
 coverage-report:
 	uv tool run diff-cover lcov.info --format markdown:report.md --compare-branch origin/master
 	$(CARGO) llvm-cov report --html
-	echo '<details summary="Full report">' >> report.md
-	grep -Go "<table>.*</table>" target/llvm-cov/html/index.html >> report.md
+	echo '<details><summary>Full report</summary>' >> report.md
+	grep -Go "<table>.*</table>" target/llvm-cov/html/index.html | sed -Ee 's|<(/{0,1})pre>|<\1code>|g' >> report.md
 	echo '</details>' >> report.md
 

--- a/Makefile
+++ b/Makefile
@@ -69,4 +69,4 @@ coverage:
 	$(CARGO) llvm-cov --all --lcov --output-path lcov.info
 
 coverage-report:
-	uv tool run diff-cover lcov.info --format markdown:report.md --compare-branch origin/master
+	uv tool run diff-cover lcov.info --format markdown:report.md --compare-branch master


### PR DESCRIPTION
Codecov has been flaky for a while and now it's started failing entirely. For some reason, it says there is no coverage data, despite a lcov.info file being fully successfully uploaded to their site. I can download it back from them and it's a non-empty lcov file.

So I'm going to try to scrape together something that doesn't rely on proprietary SaaS and see how it goes.

This PR adds something based on the Python `diff_cover` tool with some extra information shoved in, then posted as a comment on the PR.

Eventually I'd like to gain back the ability to see the total % coverage change vs the merge base, but this seems to be almost impossible with Github Actions.