### PR TITLE
Relative dates

### DIFF
--- a/core/datepatterns.txt
+++ b/core/datepatterns.txt
@@ -25,3 +25,11 @@ isoyear monthname day[ hour24:min[:sec][ offset]]
 # Today dates
 hour12:min[:sec] meridiem[ offset]
 hour24:min[:sec][ offset]
+
+# Relative offsets
+today&relative hour12:min[:sec] meridiem[ offset]
+today&relative hour24:min[:sec][ offset]
+today&relative
+now&relative
+today
+now

--- a/core/src/ast/def.rs
+++ b/core/src/ast/def.rs
@@ -30,6 +30,9 @@ pub enum DateMatch {
     Sec,
     WeekDay,
     Year,
+    Today,
+    Now,
+    Relative,
 }
 
 impl DateMatch {
@@ -54,6 +57,9 @@ impl DateMatch {
             "sec" => Some(DateMatch::Sec),
             "weekday" => Some(DateMatch::WeekDay),
             "year" => Some(DateMatch::Year),
+            "today" => Some(DateMatch::Today),
+            "now" => Some(DateMatch::Now),
+            "relative" => Some(DateMatch::Relative),
             _ => None,
         }
     }
@@ -79,6 +85,9 @@ impl DateMatch {
             DateMatch::Sec => "sec",
             DateMatch::WeekDay => "weekday",
             DateMatch::Year => "year",
+            DateMatch::Today => "today",
+            DateMatch::Now => "now",
+            DateMatch::Relative => "relative",
         }
     }
 }

--- a/core/src/ast/def.rs
+++ b/core/src/ast/def.rs
@@ -295,4 +295,36 @@ mod tests {
             "['a']"
         );
     }
+
+    #[test]
+    fn roundtrip() {
+        let all_patterns = [
+            DateMatch::Day,
+            DateMatch::Era,
+            DateMatch::FullDay,
+            DateMatch::FullHour12,
+            DateMatch::FullHour24,
+            DateMatch::FullYear,
+            DateMatch::Hour12,
+            DateMatch::Hour24,
+            DateMatch::IsoWeek,
+            DateMatch::IsoYear,
+            DateMatch::Meridiem,
+            DateMatch::Min,
+            DateMatch::MonthName,
+            DateMatch::MonthNum,
+            DateMatch::Offset,
+            DateMatch::Ordinal,
+            DateMatch::Sec,
+            DateMatch::WeekDay,
+            DateMatch::Year,
+            DateMatch::Today,
+            DateMatch::Now,
+            DateMatch::Relative,
+        ];
+
+        for pattern in all_patterns {
+            assert_eq!(DateMatch::from_str(pattern.name()), Some(pattern));
+        }
+    }
 }

--- a/core/src/parsing/datetime.rs
+++ b/core/src/parsing/datetime.rs
@@ -1441,6 +1441,11 @@ mod tests {
         );
 
         assert_eq!(
+            attempt(&now, &now_plus_xy(-1, "min"), pattern),
+            Ok(dt("2016-08-02 15:32:19[America/New_York]"))
+        );
+
+        assert_eq!(
             attempt(&now, &now_plus_xy(1, "hr"), pattern),
             Ok(dt("2016-08-02 16:33:19[America/New_York]"))
         );

--- a/core/tests/query.rs
+++ b/core/tests/query.rs
@@ -1033,3 +1033,49 @@ fn date_formats() {
         "2016-08-02 20:16:14 [UTC] (in 42 minutes)"
     );
 }
+
+#[test]
+fn test_relative() {
+    // today&relative hour12:min[:sec] meridiem[ offset]
+    assert_eq!(
+        exec("#today+2months 08:00 am"),
+        "2016-10-02 08:00:00 [America/New_York] (in 1 month)"
+    );
+    assert_eq!(
+        exec("#today+2months 08:00 am US/Pacific"),
+        "2016-10-02 08:00:00 [US/Pacific] (in 1 month)"
+    );
+    // today&relative hour24:min[:sec][ offset]
+    assert_eq!(
+        exec("#today+2months 13:00"),
+        "2016-10-02 13:00:00 [America/New_York] (in 1 month)"
+    );
+    // today&relative
+    assert_eq!(
+        exec("#today+1d#"),
+        "2016-08-03 00:00:00 [America/New_York] (in 8 hours)"
+    );
+    assert_eq!(
+        exec("#today-3w#"),
+        "2016-07-12 00:00:00 [America/New_York] (3 weeks ago)"
+    );
+    // now&relative
+    assert_eq!(
+        exec("#now+1h#"),
+        "2016-08-02 16:33:19 [America/New_York] (in 1 hour)"
+    );
+    assert_eq!(
+        exec("#now-30min#"),
+        "2016-08-02 15:03:19 [America/New_York] (30 minutes ago)"
+    );
+    // today
+    assert_eq!(
+        exec("#today#"),
+        "2016-08-02 00:00:00 [America/New_York] (15 hours ago)"
+    );
+    // now
+    assert_eq!(
+        exec("#now#"),
+        "2016-08-02 15:33:19 [America/New_York] (now)"
+    );
+}

--- a/docs/rink-dates.5.adoc
+++ b/docs/rink-dates.5.adoc
@@ -55,10 +55,6 @@ The valid keywords are:
 	The ISO year, like -0001. Must be exactly 4 digits. ISO year unifies
 	CE and BCE such that 1BC is year 0, and 2BCE is year -1.
 
-**unix**::
-	Unix timestamp, i.e. the number of 1/86400ths of a day elapsed since
-	January 1st, 1970. Can be any number of digits.
-
 **year**::
 	The current year, like 2024. Can be any number of digits.
 
@@ -94,6 +90,19 @@ The valid keywords are:
 	Makes English weekday names, case insensitive. Recognizes 3-letter
 	names (like mon, tue, wed) and full names.
 
+**today**:: 
+	Use the current date, but not the time. Most useful when combined
+	with `relative`.
+
+**now**::
+	Use the current time and date. Most useful when combined with
+	`relative`.
+
+**relative**::
+	Matches a relative unit, like `+1h` to add 1 hour, or `-7week` to
+	subtract 7 weeks. This is calendar aware, instead of working in
+	seconds.
+
 **`-`**::
 	Matches a literal `-` character.
 
@@ -102,6 +111,10 @@ The valid keywords are:
 
 ` `::
 	A single space will match any amount of whitespace.
+
+`&`::
+	Allows putting two terms directly next to each other without spaces
+	in between.
 
 **`'`** <__anything__> **`'`**::
 	Wrapping text in single quotes will match that text literally.

--- a/docs/rink.7.adoc
+++ b/docs/rink.7.adoc
@@ -485,6 +485,13 @@ Inputting a time with an offset:
 	> #apr 1, 2016 12:00:00 +01:00#
 	2016-04-01 12:00:00 +01:00 (6 years ago)
 
+Calendar-aware relative dates:
+
+	> #today#
+	2025-08-16 00:00:00 [US/Pacific] (23 hours ago)
+	> #today+1mon#
+	2025-09-16 00:00:00 [US/Pacific] (in 30 days)
+
 Substances
 ~~~~~~~~~~
 


### PR DESCRIPTION
This is an update of the changes from #185.

Adds relative dates, using a slightly different syntax from the original PR. Adds a `today` token and a way to apply time offsets to it. So you can write `#today+1wk#` to get the date 1 week in the future.