### PR TITLE
Deferred currency fetching

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -66,7 +66,7 @@ installfiles:
 install: installbin installman installfiles
 
 coverage:
-	$(CARGO) llvm-cov --all --lcov --output-path lcov.info
+	$(CARGO) llvm-cov --all --lcov --output-path lcov.info --all-features
 
 coverage-report:
 	uv tool run diff-cover lcov.info --format markdown:report.md --compare-branch origin/master

--- a/cli/src/config.rs
+++ b/cli/src/config.rs
@@ -62,10 +62,8 @@ pub struct Rink {
 #[derive(Serialize, Deserialize, Clone, PartialEq, Eq)]
 #[serde(rename_all = "lowercase")]
 pub enum CurrencyBehavior {
-    Default,
     Prompt,
     Always,
-    Disabled,
 }
 
 #[derive(Serialize, Deserialize, Clone)]
@@ -188,19 +186,13 @@ impl Default for Config {
 impl Default for Currency {
     fn default() -> Self {
         Currency {
-            behavior: CurrencyBehavior::Default,
+            behavior: CurrencyBehavior::Prompt,
             enabled: true,
             fetch_on_startup: true,
             endpoint: "https://rinkcalc.app/data/currency.json".to_owned(),
             cache_duration: Duration::from_secs(60 * 60), // 1 hour
             timeout: Duration::from_secs(2),
         }
-    }
-}
-
-impl Currency {
-    pub fn should_load_defs(&self) -> bool {
-        self.enabled && self.behavior != CurrencyBehavior::Disabled
     }
 }
 
@@ -384,7 +376,7 @@ pub fn load(config: &Config) -> Result<Context> {
     ctx.load_dates(datetime::parse_datefile(&dates));
 
     // Load currency data.
-    if config.currency.should_load_defs() {
+    if config.currency.enabled {
         match try_load_currency(&config.currency, &mut ctx, &search_path) {
             Ok(()) => (),
             Err(err) => {

--- a/cli/src/config.rs
+++ b/cli/src/config.rs
@@ -74,7 +74,8 @@ pub struct Currency {
     /// Set to false to disable currency loading entirely.
     pub enabled: bool,
     /// Set to false to only reuse the existing cached currency data.
-    pub fetch_on_startup: bool,
+    #[serde(alias = "fetch_on_startup")]
+    pub cache_expiration_enabled: bool,
     /// Which web endpoint should be used to download currency data?
     pub endpoint: String,
     /// How long to cache for.
@@ -188,7 +189,7 @@ impl Default for Currency {
         Currency {
             behavior: CurrencyBehavior::Prompt,
             enabled: true,
-            fetch_on_startup: true,
+            cache_expiration_enabled: true,
             endpoint: "https://rinkcalc.app/data/currency.json".to_owned(),
             cache_duration: Duration::from_secs(60 * 60), // 1 hour
             timeout: Duration::from_secs(2),
@@ -290,7 +291,7 @@ pub fn force_refresh_currency(config: &Currency) -> Result<String> {
 }
 
 pub(crate) fn load_live_currency(config: &Currency) -> Result<String> {
-    let duration = if config.fetch_on_startup {
+    let duration = if config.cache_expiration_enabled {
         Some(config.cache_duration)
     } else {
         None

--- a/cli/src/config.rs
+++ b/cli/src/config.rs
@@ -192,7 +192,7 @@ impl Default for Currency {
             cache_expiration_enabled: true,
             endpoint: "https://rinkcalc.app/data/currency.json".to_owned(),
             cache_duration: Duration::from_secs(60 * 60), // 1 hour
-            timeout: Duration::from_secs(2),
+            timeout: Duration::from_secs(15),
         }
     }
 }

--- a/cli/src/config.rs
+++ b/cli/src/config.rs
@@ -2,38 +2,36 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
+use crate::currency::try_load_currency;
 use crate::style_ser;
 use color_eyre::Result;
-use curl::easy::Easy;
-use eyre::{eyre, Report, WrapErr};
+use eyre::{eyre, WrapErr};
 use nu_ansi_term::{Color, Style};
+use rink_core::loader::gnu_units;
 use rink_core::output::fmt::FmtToken;
 use rink_core::parsing::datetime;
 use rink_core::Context;
-use rink_core::{loader::gnu_units, CURRENCY_FILE, DATES_FILE, DEFAULT_FILE};
+use rink_core::{DATES_FILE, DEFAULT_FILE};
 use serde_derive::{Deserialize, Serialize};
+use std::collections::HashMap;
 use std::env;
-use std::ffi::OsString;
-use std::io::{ErrorKind, Read, Seek, SeekFrom, Write};
-use std::path::Path;
+use std::fs::read_to_string;
+use std::io::ErrorKind;
 use std::path::PathBuf;
 use std::time::Duration;
-use std::{
-    collections::HashMap,
-    fs::{read_to_string, File},
-};
 use ubyte::ByteUnit;
 
-fn file_to_string(mut file: File) -> Result<String> {
-    let mut string = String::new();
-    let _ = file.read_to_string(&mut string)?;
-    Ok(string)
-}
-
-pub fn config_path(name: &str) -> Result<PathBuf> {
+pub fn config_toml_path() -> Result<PathBuf> {
     let mut path = dirs::config_dir().ok_or_else(|| eyre!("Could not find config directory"))?;
     path.push("rink");
-    path.push(name);
+    path.push("config.toml");
+    Ok(path)
+}
+
+pub fn currency_json_path() -> Result<PathBuf> {
+    let mut path = dirs::cache_dir().ok_or_else(|| eyre!("Could not find cache directory"))?;
+    path.push("rink");
+    path.push("currency.json");
     Ok(path)
 }
 
@@ -241,7 +239,7 @@ impl Config {
     }
 }
 
-fn read_from_search_path(
+pub(crate) fn read_from_search_path(
     filename: &str,
     paths: &[PathBuf],
     default: Option<&'static str>,
@@ -271,58 +269,11 @@ fn read_from_search_path(
     }
 }
 
-pub fn force_refresh_currency(config: &Currency) -> Result<String> {
-    println!("Fetching...");
-    let start = std::time::Instant::now();
-    let mut path = dirs::cache_dir().ok_or_else(|| eyre!("Could not find cache directory"))?;
-    path.push("rink");
-    path.push("currency.json");
-    let file = download_to_file(&path, &config.endpoint, config.timeout)
-        .wrap_err("Fetching currency data failed")?;
-    let delta = std::time::Instant::now() - start;
-    let metadata = file
-        .metadata()
-        .wrap_err("Fetched currency file, but failed to read file metadata")?;
-    let len = metadata.len();
-    Ok(format!(
-        "Fetched {len} byte currency file after {}ms",
-        delta.as_millis()
-    ))
-}
-
-pub(crate) fn load_live_currency(config: &Currency) -> Result<String> {
-    let duration = if config.cache_expiration_enabled {
-        Some(config.cache_duration)
-    } else {
-        None
-    };
-    let file = cached("currency.json", &config.endpoint, duration, config.timeout)?;
-    let contents = file_to_string(file)?;
-    Ok(contents)
-}
-
-fn try_load_currency(config: &Currency, ctx: &mut Context, search_path: &[PathBuf]) -> Result<()> {
-    let base = read_from_search_path("currency.units", search_path, CURRENCY_FILE)?
-        .into_iter()
-        .collect::<Vec<_>>()
-        .join("\n");
-    let duration = config.cache_duration;
-    let cached = cached_nofetch("currency.json", Some(duration))?;
-    let contents = if let Some(cached) = cached {
-        Some(file_to_string(cached)?)
-    } else {
-        None
-    };
-    ctx.load_currency(contents.as_ref().map(|s| &s[..]), &base.as_str())
-        .map_err(|err| eyre!("{err}"))?;
-    Ok(())
-}
-
 pub fn read_config(override_path: Option<&str>) -> Result<Config> {
     let path = if let Some(path) = override_path {
         PathBuf::from(path)
     } else {
-        config_path("config.toml")?
+        config_toml_path()?
     };
     match read_to_string(path) {
         // Hard fail if the file has invalid TOML.
@@ -378,139 +329,10 @@ pub fn load(config: &Config) -> Result<Context> {
 
     // Load currency data.
     if config.currency.enabled {
-        match try_load_currency(&config.currency, &mut ctx, &search_path) {
-            Ok(()) => (),
-            Err(err) => {
-                println!("{:?}", err.wrap_err("Failed to load currency data"));
-            }
+        if let Err(err) = try_load_currency(&config.currency, &mut ctx, &search_path) {
+            println!("{:?}", err.wrap_err("Failed to load currency data"));
         }
     }
 
     Ok(ctx)
-}
-
-fn read_if_current(file: File, expiration: Option<Duration>) -> Result<File> {
-    use std::time::SystemTime;
-
-    let stats = file.metadata()?;
-    let mtime = stats.modified()?;
-    let now = SystemTime::now();
-    let elapsed = now.duration_since(mtime)?;
-    if let Some(expiration) = expiration {
-        if elapsed > expiration {
-            return Err(eyre!("File is out of date"));
-        }
-    }
-    Ok(file)
-}
-
-pub fn download_to_file(path: &Path, url: &str, timeout: Duration) -> Result<File> {
-    use std::fs::create_dir_all;
-
-    create_dir_all(path.parent().unwrap())?;
-
-    // Given a filename like `foo.json`, names the temp file something
-    // similar, like `foo.ABCDEF.json`.
-    let mut prefix = path.file_stem().unwrap().to_owned();
-    prefix.push(".");
-    let mut suffix = OsString::from(".");
-    suffix.push(path.extension().unwrap());
-
-    // The temp file should be created in the same directory as its
-    // final home, as the default temporary file directory might not be
-    // the same filesystem.
-    let mut temp_file = tempfile::Builder::new()
-        .prefix(&prefix)
-        .suffix(&suffix)
-        .tempfile_in(path.parent().unwrap())?;
-
-    let mut easy = Easy::new();
-    easy.url(url)?;
-    easy.useragent(&format!(
-        "rink-cli {} <{}>",
-        env!("CARGO_PKG_VERSION"),
-        env!("CARGO_PKG_REPOSITORY")
-    ))?;
-    easy.timeout(timeout)?;
-
-    let mut write_handle = temp_file.as_file_mut().try_clone()?;
-    easy.write_function(move |data| {
-        write_handle
-            .write(data)
-            .map_err(|_| curl::easy::WriteError::Pause)
-    })?;
-    easy.perform()?;
-
-    let status = easy.response_code()?;
-    if status != 200 {
-        return Err(eyre!(
-            "Received status {} while downloading {}",
-            status,
-            url
-        ));
-    }
-
-    temp_file.as_file_mut().sync_all()?;
-    temp_file.as_file_mut().seek(SeekFrom::Start(0))?;
-
-    temp_file
-        .persist(path)
-        .wrap_err("Failed to write to cache dir")
-}
-
-fn cached_nofetch(filename: &str, expiration: Option<Duration>) -> Result<Option<File>> {
-    let mut path = dirs::cache_dir().ok_or_else(|| eyre!("Could not find cache directory"))?;
-    path.push("rink");
-    path.push(filename);
-
-    // 1. Return file if it exists and is up to date.
-    // 2. Try to download a new version of the file and return it.
-    // 3. If that fails, return the stale file if it exists.
-
-    if let Ok(file) = File::open(&path) {
-        if let Ok(result) = read_if_current(file, expiration) {
-            return Ok(Some(result));
-        }
-    }
-    Ok(None)
-}
-
-fn cached(
-    filename: &str,
-    url: &str,
-    expiration: Option<Duration>,
-    timeout: Duration,
-) -> Result<File> {
-    let mut path = dirs::cache_dir().ok_or_else(|| eyre!("Could not find cache directory"))?;
-    path.push("rink");
-    path.push(filename);
-
-    // 1. Return file if it exists and is up to date.
-    // 2. Try to download a new version of the file and return it.
-    // 3. If that fails, return the stale file if it exists.
-
-    if let Ok(file) = File::open(&path) {
-        if let Ok(result) = read_if_current(file, expiration) {
-            return Ok(result);
-        }
-    }
-
-    let err = match download_to_file(&path, url, timeout) {
-        Ok(result) => return Ok(result),
-        Err(err) => err,
-    };
-
-    if let Ok(file) = File::open(&path) {
-        // Indicate error even though we're returning success.
-        println!(
-            "{:?}",
-            Report::wrap_err(
-                err,
-                format!("Failed to refresh {}, using stale version", url)
-            )
-        );
-        Ok(file)
-    } else {
-        Err(err).wrap_err_with(|| format!("Failed to fetch {}", url))
-    }
 }

--- a/cli/src/currency.rs
+++ b/cli/src/currency.rs
@@ -1,0 +1,190 @@
+use std::ffi::OsString;
+use std::io::{Read, Seek, SeekFrom, Write};
+use std::path::PathBuf;
+use std::time::Duration;
+use std::{fs::File, path::Path};
+
+use crate::config::{read_from_search_path, Currency};
+use color_eyre::Result;
+use curl::easy::Easy;
+use eyre::{eyre, Context as _, Report};
+use rink_core::{Context, CURRENCY_FILE};
+
+fn file_to_string(mut file: File) -> Result<String> {
+    let mut string = String::new();
+    let _size = file.read_to_string(&mut string)?;
+    Ok(string)
+}
+
+/// Used when rink is run with `--fetch-currency`
+pub fn force_refresh_currency(config: &Currency) -> Result<String> {
+    println!("Fetching...");
+    let start = std::time::Instant::now();
+    let mut path = dirs::cache_dir().ok_or_else(|| eyre!("Could not find cache directory"))?;
+    path.push("rink");
+    path.push("currency.json");
+    let file = download_to_file(&path, &config.endpoint, config.timeout)
+        .wrap_err("Fetching currency data failed")?;
+    let delta = std::time::Instant::now() - start;
+    let metadata = file
+        .metadata()
+        .wrap_err("Fetched currency file, but failed to read file metadata")?;
+    let len = metadata.len();
+    Ok(format!(
+        "Fetched {len} byte currency file after {}ms",
+        delta.as_millis()
+    ))
+}
+
+pub(crate) fn load_live_currency(config: &Currency) -> Result<String> {
+    let duration = if config.cache_expiration_enabled {
+        Some(config.cache_duration)
+    } else {
+        None
+    };
+    let file = cached("currency.json", &config.endpoint, duration, config.timeout)?;
+    let contents = file_to_string(file)?;
+    Ok(contents)
+}
+
+pub(crate) fn try_load_currency(
+    config: &Currency,
+    ctx: &mut Context,
+    search_path: &[PathBuf],
+) -> Result<()> {
+    let base = read_from_search_path("currency.units", search_path, CURRENCY_FILE)?
+        .into_iter()
+        .collect::<Vec<_>>()
+        .join("\n");
+    let duration = config.cache_duration;
+    let cached = cached_nofetch("currency.json", Some(duration))?;
+    let contents = if let Some(cached) = cached {
+        Some(file_to_string(cached)?)
+    } else {
+        None
+    };
+    ctx.load_currency(contents.as_ref().map(|s| &s[..]), &base.as_str())
+        .map_err(|err| eyre!("{err}"))?;
+    Ok(())
+}
+
+fn read_if_current(path: &Path, expiration: Option<Duration>) -> Result<Option<File>> {
+    use std::time::SystemTime;
+
+    let file = match File::open(&path) {
+        Ok(file) => file,
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => return Ok(None),
+        Err(err) => return Err(err.into()),
+    };
+    let stats = file.metadata()?;
+    let mtime = stats.modified()?;
+    let now = SystemTime::now();
+    let elapsed = now.duration_since(mtime)?;
+    if let Some(expiration) = expiration {
+        if elapsed > expiration {
+            return Ok(None);
+        }
+    }
+    Ok(Some(file))
+}
+
+pub fn download_to_file(path: &Path, url: &str, timeout: Duration) -> Result<File> {
+    use std::fs::create_dir_all;
+
+    create_dir_all(path.parent().unwrap())?;
+
+    // Given a filename like `foo.json`, names the temp file something
+    // similar, like `foo.ABCDEF.json`.
+    let mut prefix = path.file_stem().unwrap().to_owned();
+    prefix.push(".");
+    let mut suffix = OsString::from(".");
+    suffix.push(path.extension().unwrap());
+
+    // The temp file should be created in the same directory as its
+    // final home, as the default temporary file directory might not be
+    // the same filesystem.
+    let mut temp_file = tempfile::Builder::new()
+        .prefix(&prefix)
+        .suffix(&suffix)
+        .tempfile_in(path.parent().unwrap())?;
+
+    let mut easy = Easy::new();
+    easy.url(url)?;
+    easy.useragent(&format!(
+        "rink-cli {} <{}>",
+        env!("CARGO_PKG_VERSION"),
+        env!("CARGO_PKG_REPOSITORY")
+    ))?;
+    easy.timeout(timeout)?;
+
+    let mut write_handle = temp_file.as_file_mut().try_clone()?;
+    easy.write_function(move |data| {
+        write_handle
+            .write(data)
+            .map_err(|_| curl::easy::WriteError::Pause)
+    })?;
+    easy.perform()?;
+
+    let status = easy.response_code()?;
+    if status != 200 {
+        return Err(eyre!(
+            "Received status {} while downloading {}",
+            status,
+            url
+        ));
+    }
+
+    temp_file.as_file_mut().sync_all()?;
+    temp_file.as_file_mut().seek(SeekFrom::Start(0))?;
+
+    temp_file
+        .persist(path)
+        .wrap_err("Failed to write to cache dir")
+}
+
+pub fn get_cache_file(filename: &str) -> Result<PathBuf> {
+    let mut path = dirs::cache_dir().ok_or_else(|| eyre!("Could not find cache directory"))?;
+    path.push("rink");
+    path.push(filename);
+    Ok(path)
+}
+
+fn cached_nofetch(filename: &str, expiration: Option<Duration>) -> Result<Option<File>> {
+    let path = get_cache_file(filename)?;
+    read_if_current(&path, expiration)
+}
+
+fn cached(
+    filename: &str,
+    url: &str,
+    expiration: Option<Duration>,
+    timeout: Duration,
+) -> Result<File> {
+    // 1. Return file if it exists and is up to date.
+    // 2. Try to download a new version of the file and return it.
+    // 3. If that fails, return the stale file if it exists.
+
+    let path = get_cache_file(filename)?;
+    if let Ok(Some(file)) = read_if_current(&path, expiration) {
+        return Ok(file);
+    }
+
+    let err = match download_to_file(&path, url, timeout) {
+        Ok(result) => return Ok(result),
+        Err(err) => err,
+    };
+
+    if let Ok(file) = File::open(&path) {
+        // Indicate error even though we're returning success.
+        println!(
+            "{:?}",
+            Report::wrap_err(
+                err,
+                format!("Failed to refresh {}, using stale version", url)
+            )
+        );
+        Ok(file)
+    } else {
+        Err(err).wrap_err_with(|| format!("Failed to fetch {}", url))
+    }
+}

--- a/cli/src/currency.rs
+++ b/cli/src/currency.rs
@@ -1,8 +1,9 @@
 use std::ffi::OsString;
+use std::fs::File;
 use std::io::{Read, Seek, SeekFrom, Write};
+use std::path::Path;
 use std::path::PathBuf;
 use std::time::Duration;
-use std::{fs::File, path::Path};
 
 use crate::config::{read_from_search_path, Currency};
 use color_eyre::Result;

--- a/cli/src/lib.rs
+++ b/cli/src/lib.rs
@@ -6,6 +6,7 @@ use rink_sandbox::Alloc;
 
 pub use helper::RinkHelper;
 pub mod config;
+pub mod currency;
 pub mod fmt;
 pub mod helper;
 pub mod repl;

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -80,7 +80,7 @@ fn main() -> Result<ExitCode> {
     }
 
     if matches.get_flag("fetch-currency") {
-        let result = rink::currency::force_refresh_currency(&config.currency);
+        let result = rink::currency::force_fetch_currency(&config.currency);
         match result {
             Ok(msg) => {
                 println!("{msg}");

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -80,7 +80,7 @@ fn main() -> Result<ExitCode> {
     }
 
     if matches.get_flag("fetch-currency") {
-        let result = config::force_refresh_currency(&config.currency);
+        let result = rink::currency::force_refresh_currency(&config.currency);
         match result {
             Ok(msg) => {
                 println!("{msg}");
@@ -91,7 +91,7 @@ fn main() -> Result<ExitCode> {
     }
 
     if matches.get_flag("config-path") {
-        println!("{}", config::config_path("config.toml").unwrap().display());
+        println!("{}", config::config_toml_path().unwrap().display());
         Ok(ExitCode::SUCCESS)
     } else if let Some(filename) = matches.get_one::<String>("file") {
         match &filename[..] {

--- a/cli/src/repl.rs
+++ b/cli/src/repl.rs
@@ -73,7 +73,13 @@ fn on_missing_deps(config: &Config, rl: &mut Editor<RinkHelper>) -> Result<Optio
     };
     if should_fetch {
         let start = Timestamp::now();
-        let res = crate::config::load_live_currency(&config.currency)?;
+        let res = match crate::config::load_live_currency(&config.currency) {
+            Ok(res) => res,
+            Err(err) => {
+                println!("{err:#}");
+                return Ok(None);
+            }
+        };
         let stop = Timestamp::now();
         let delta = stop - start;
         println!(

--- a/cli/src/repl.rs
+++ b/cli/src/repl.rs
@@ -66,10 +66,7 @@ fn on_missing_deps(config: &Config, rl: &mut Editor<RinkHelper>) -> Result<Optio
             println!("Downloading {}...", config.currency.endpoint);
             true
         }
-        CurrencyBehavior::Disabled => false,
-        CurrencyBehavior::Default | CurrencyBehavior::Prompt => {
-            prompt_load_currency(&config.currency.endpoint, rl)?
-        }
+        CurrencyBehavior::Prompt => prompt_load_currency(&config.currency.endpoint, rl)?,
     };
     if should_fetch {
         let start = Timestamp::now();

--- a/cli/src/repl.rs
+++ b/cli/src/repl.rs
@@ -2,15 +2,17 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-use crate::config::CurrencyBehavior;
+use crate::config::{Config, CurrencyBehavior};
 use crate::currency::CurrencyStatus;
 use crate::runner::Runner;
+use crate::service::EvalResult;
 use crate::RinkHelper;
-use crate::{config::Config, service::EvalResult};
 use eyre::Result;
 use jiff::{Timestamp, Unit};
 use rink_core::one_line;
-use rustyline::{config::Configurer, error::ReadlineError, CompletionType, Editor};
+use rustyline::config::Configurer;
+use rustyline::error::ReadlineError;
+use rustyline::{CompletionType, Editor};
 use std::io::{BufRead, ErrorKind};
 
 pub fn noninteractive<T: BufRead>(mut f: T, config: &Config, show_prompt: bool) -> Result<()> {

--- a/cli/src/runner.rs
+++ b/cli/src/runner.rs
@@ -2,9 +2,9 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
+use crate::config::Config;
 use crate::fmt::to_ansi_string;
-use crate::service::RinkService;
-use crate::{config::Config, service::EvalResult};
+use crate::service::{EvalResult, RinkService};
 use eyre::Result;
 use rink_core::output::QueryError;
 use rink_sandbox::Sandbox;

--- a/cli/src/service.rs
+++ b/cli/src/service.rs
@@ -2,7 +2,9 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-use crate::{config::Config, fmt::to_ansi_string, GLOBAL};
+use crate::config::Config;
+use crate::fmt::to_ansi_string;
+use crate::GLOBAL;
 use rink_core::output::QueryError;
 use rink_core::runtime::MissingDeps;
 use rink_core::{eval, Context};

--- a/cli/src/service.rs
+++ b/cli/src/service.rs
@@ -3,8 +3,11 @@
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
 use crate::{config::Config, fmt::to_ansi_string, GLOBAL};
+use rink_core::output::QueryError;
+use rink_core::runtime::MissingDeps;
 use rink_core::{eval, Context};
 use rink_sandbox::Service;
+use serde_derive::{Deserialize, Serialize};
 use std::sync::{Arc, Mutex};
 
 pub struct RinkService {
@@ -12,9 +15,15 @@ pub struct RinkService {
     ctx: Arc<Mutex<Context>>,
 }
 
+#[derive(Serialize, Deserialize)]
+pub enum EvalResult {
+    AnsiString(String),
+    MissingDeps(MissingDeps),
+}
+
 impl Service for RinkService {
     type Req = String;
-    type Res = Result<String, String>;
+    type Res = EvalResult;
     type Config = Config;
 
     fn args(_config: &Self::Config) -> Vec<std::ffi::OsString> {
@@ -38,8 +47,9 @@ impl Service for RinkService {
     fn handle(&self, request: Self::Req) -> Self::Res {
         let mut ctx = self.ctx.lock().unwrap();
         match eval(&mut ctx, &request) {
-            Ok(value) => Ok(to_ansi_string(&self.config, &value)),
-            Err(err) => Err(to_ansi_string(&self.config, &err)),
+            Ok(value) => EvalResult::AnsiString(to_ansi_string(&self.config, &value)),
+            Err(QueryError::MissingDeps(deps)) => EvalResult::MissingDeps(deps),
+            Err(err) => EvalResult::AnsiString(to_ansi_string(&self.config, &err)),
         }
     }
 

--- a/cli/tests/config_sandboxed_local_server.toml
+++ b/cli/tests/config_sandboxed_local_server.toml
@@ -6,4 +6,4 @@ show_metrics = true
 enabled = true
 behavior = "prompt"
 endpoint = "http://127.0.0.1:3090/data/currency.json"
-cache_duration = "1s"
+cache_duration = "10s"

--- a/cli/tests/config_sandboxed_local_server.toml
+++ b/cli/tests/config_sandboxed_local_server.toml
@@ -1,0 +1,9 @@
+[limits]
+enabled = true
+show_metrics = true
+
+[currency]
+enabled = true
+behavior = "prompt"
+endpoint = "http://127.0.0.1:3090/data/currency.json"
+cache_duration = "1s"

--- a/cli/tests/http_test.rs
+++ b/cli/tests/http_test.rs
@@ -99,6 +99,7 @@ fn test_download_success() {
 fn test_force_refresh_success() {
     let config = rink::config::Currency {
         enabled: true,
+        behavior: rink::config::CurrencyBehavior::Default,
         fetch_on_startup: false,
         endpoint: "http://127.0.0.1:3090/data/currency.json".to_owned(),
         cache_duration: Duration::ZERO,
@@ -128,6 +129,7 @@ fn test_force_refresh_success() {
 fn test_force_refresh_timeout() {
     let config = rink::config::Currency {
         enabled: true,
+        behavior: rink::config::CurrencyBehavior::Default,
         fetch_on_startup: false,
         endpoint: "http://127.0.0.1:3090/data/currency.json".to_owned(),
         cache_duration: Duration::ZERO,

--- a/cli/tests/http_test.rs
+++ b/cli/tests/http_test.rs
@@ -100,7 +100,7 @@ fn test_download_success() {
 fn test_force_refresh_success() {
     let config = rink::config::Currency {
         enabled: true,
-        behavior: rink::config::CurrencyBehavior::Default,
+        behavior: rink::config::CurrencyBehavior::Prompt,
         fetch_on_startup: false,
         endpoint: "http://127.0.0.1:3090/data/currency.json".to_owned(),
         cache_duration: Duration::ZERO,
@@ -130,7 +130,7 @@ fn test_force_refresh_success() {
 fn test_force_refresh_timeout() {
     let config = rink::config::Currency {
         enabled: true,
-        behavior: rink::config::CurrencyBehavior::Default,
+        behavior: rink::config::CurrencyBehavior::Prompt,
         fetch_on_startup: false,
         endpoint: "http://127.0.0.1:3090/data/currency.json".to_owned(),
         cache_duration: Duration::ZERO,

--- a/cli/tests/http_test.rs
+++ b/cli/tests/http_test.rs
@@ -101,7 +101,7 @@ fn test_force_refresh_success() {
     let config = rink::config::Currency {
         enabled: true,
         behavior: rink::config::CurrencyBehavior::Prompt,
-        fetch_on_startup: false,
+        cache_expiration_enabled: false,
         endpoint: "http://127.0.0.1:3090/data/currency.json".to_owned(),
         cache_duration: Duration::ZERO,
         timeout: Duration::from_millis(2000),
@@ -131,7 +131,7 @@ fn test_force_refresh_timeout() {
     let config = rink::config::Currency {
         enabled: true,
         behavior: rink::config::CurrencyBehavior::Prompt,
-        fetch_on_startup: false,
+        cache_expiration_enabled: false,
         endpoint: "http://127.0.0.1:3090/data/currency.json".to_owned(),
         cache_duration: Duration::ZERO,
         timeout: Duration::from_millis(5),

--- a/cli/tests/http_test.rs
+++ b/cli/tests/http_test.rs
@@ -23,7 +23,7 @@ fn test_download_timeout() {
         assert_eq!(request.url(), "/data/currency.json");
         std::thread::sleep(Duration::from_millis(100));
     });
-    let result = rink::config::download_to_file(
+    let result = rink::currency::download_to_file(
         &PathBuf::from("currency.json"),
         "http://127.0.0.1:3090/data/currency.json",
         Duration::from_millis(5),
@@ -50,7 +50,7 @@ fn test_download_404() {
             .respond(Response::new(StatusCode(404), vec![], cursor, None, None))
             .expect("the response should go through");
     });
-    let result = rink::config::download_to_file(
+    let result = rink::currency::download_to_file(
         &PathBuf::from("currency.json"),
         "http://127.0.0.1:3090/data/currency.json",
         Duration::from_millis(2000),
@@ -78,7 +78,7 @@ fn test_download_success() {
             .respond(Response::new(StatusCode(200), vec![], cursor, None, None))
             .expect("the response should go through");
     });
-    let result = rink::config::download_to_file(
+    let result = rink::currency::download_to_file(
         &PathBuf::from("currency.json"),
         "http://127.0.0.1:3090/data/currency.json",
         Duration::from_millis(2000),
@@ -119,7 +119,7 @@ fn test_force_refresh_success() {
             .respond(Response::new(StatusCode(200), vec![], cursor, None, None))
             .expect("the response should go through");
     });
-    let result = rink::config::force_refresh_currency(&config);
+    let result = rink::currency::force_refresh_currency(&config);
     let result = result.expect("this should succeed");
     assert!(result.starts_with("Fetched 6599 byte currency file after "));
     thread_handle.join().unwrap();
@@ -145,7 +145,7 @@ fn test_force_refresh_timeout() {
         assert_eq!(request.url(), "/data/currency.json");
         std::thread::sleep(Duration::from_millis(100));
     });
-    let result = rink::config::force_refresh_currency(&config);
+    let result = rink::currency::force_refresh_currency(&config);
     let result = result.expect_err("this should timeout");
     assert_eq!(result.to_string(), "Fetching currency data failed");
     thread_handle.join().unwrap();

--- a/core/currency.units
+++ b/core/currency.units
@@ -1,39 +1,39 @@
 !category currencies "Currencies"
 
 # Declare dependencies
-BTC                     dependency BTC
-bitcoin                 dependency bitcoin
-USD                     dependency USD
-JPY                     dependency JPY
-BGN                     dependency BGN
-CZK                     dependency CZK
-DKK                     dependency DKK
-GBP                     dependency GBP
-HUF                     dependency HUF
-PLN                     dependency PLN
-RON                     dependency RON
-SEK                     dependency SEK
-CHF                     dependency CHF
-ISK                     dependency ISK
-NOK                     dependency NOK
-TRY                     dependency TRY
-AUD                     dependency AUD
-BRL                     dependency BRL
-CAD                     dependency CAD
-CNY                     dependency CNY
-HKD                     dependency HKD
-IDR                     dependency IDR
-ILS                     dependency ILS
-INR                     dependency INR
-KRW                     dependency KRW
-MXN                     dependency MXN
-MYR                     dependency MYR
-NZD                     dependency NZD
-PHP                     dependency PHP
-SGD                     dependency SGD
-THB                     dependency THB
-ZAR                     dependency ZAR
-RUB                     dependency RUB
+!dependency BTC
+!dependency bitcoin
+!dependency USD
+!dependency JPY
+!dependency BGN
+!dependency CZK
+!dependency DKK
+!dependency GBP
+!dependency HUF
+!dependency PLN
+!dependency RON
+!dependency SEK
+!dependency CHF
+!dependency ISK
+!dependency NOK
+!dependency TRY
+!dependency AUD
+!dependency BRL
+!dependency CAD
+!dependency CNY
+!dependency HKD
+!dependency IDR
+!dependency ILS
+!dependency INR
+!dependency KRW
+!dependency MXN
+!dependency MYR
+!dependency NZD
+!dependency PHP
+!dependency SGD
+!dependency THB
+!dependency ZAR
+!dependency RUB
 
 # Symbols + names
 # EU

--- a/core/currency.units
+++ b/core/currency.units
@@ -1,7 +1,39 @@
 !category currencies "Currencies"
 
-EUR                     !euro
-money                 ? EUR
+# Declare dependencies
+BTC                     dependency BTC
+bitcoin                 dependency bitcoin
+USD                     dependency USD
+JPY                     dependency JPY
+BGN                     dependency BGN
+CZK                     dependency CZK
+DKK                     dependency DKK
+GBP                     dependency GBP
+HUF                     dependency HUF
+PLN                     dependency PLN
+RON                     dependency RON
+SEK                     dependency SEK
+CHF                     dependency CHF
+ISK                     dependency ISK
+NOK                     dependency NOK
+TRY                     dependency TRY
+AUD                     dependency AUD
+BRL                     dependency BRL
+CAD                     dependency CAD
+CNY                     dependency CNY
+HKD                     dependency HKD
+IDR                     dependency IDR
+ILS                     dependency ILS
+INR                     dependency INR
+KRW                     dependency KRW
+MXN                     dependency MXN
+MYR                     dependency MYR
+NZD                     dependency NZD
+PHP                     dependency PHP
+SGD                     dependency SGD
+THB                     dependency THB
+ZAR                     dependency ZAR
+RUB                     dependency RUB
 
 # Symbols + names
 # EU

--- a/core/definitions.units
+++ b/core/definitions.units
@@ -234,6 +234,10 @@ bit       !
 ?? WHO TRS 932, Annex 2.
 IU                              !
 
+?? The Euro is used as the base unit for money in Rink because
+?? currency data is fetched from the European Central Bank.
+EUR                     !euro
+
 !endcategory
 
 ###########################################################################
@@ -697,6 +701,7 @@ fuel_efficiency         ? area^-1
 molar_mass              ? mass / amount
 flow_rate               ? volume / time
 pressure_column         ? pressure / length
+money                   ? EUR
 
 # XXX: conflates “biological activity” and “immunological activity” to
 # avoid a conflicting quantities warning; some biological agents have

--- a/core/src/ast/def.rs
+++ b/core/src/ast/def.rs
@@ -141,7 +141,7 @@ impl Deref for ExprString {
     }
 }
 
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize, PartialEq)]
 #[serde(rename_all = "camelCase")]
 pub struct Property {
     pub name: String,
@@ -152,7 +152,7 @@ pub struct Property {
     pub doc: Option<String>,
 }
 
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize, PartialEq)]
 #[serde(rename_all = "camelCase")]
 #[serde(tag = "type")]
 pub enum Def {
@@ -187,7 +187,7 @@ pub enum Def {
     },
 }
 
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize, PartialEq)]
 pub struct DefEntry {
     pub name: String,
     #[serde(flatten)]

--- a/core/src/ast/def.rs
+++ b/core/src/ast/def.rs
@@ -179,6 +179,9 @@ pub enum Def {
         #[serde(rename = "displayName")]
         display_name: String,
     },
+    Dependency {
+        name: String,
+    },
     Error {
         message: String,
     },

--- a/core/src/ast/expr.rs
+++ b/core/src/ast/expr.rs
@@ -10,7 +10,6 @@ use serde_derive::Serialize;
 #[serde(tag = "type")]
 pub enum Expr {
     Unit { name: String },
-    Dependency { name: String },
     Quote { string: String },
     Const { value: Numeric },
     Date { tokens: Vec<DateToken> },
@@ -33,10 +32,6 @@ impl Expr {
 
     pub fn new_unit(name: String) -> Expr {
         Expr::Unit { name }
-    }
-
-    pub fn new_dependency(name: String) -> Expr {
-        Expr::Dependency { name }
     }
 
     pub fn new_call(func: Function, args: Vec<Expr>) -> Expr {
@@ -152,7 +147,6 @@ impl fmt::Display for Expr {
         fn recurse(expr: &Expr, fmt: &mut fmt::Formatter<'_>, prec: Precedence) -> fmt::Result {
             match *expr {
                 Expr::Unit { ref name } => write!(fmt, "{}", name),
-                Expr::Dependency { ref name } => write!(fmt, "dependency {}", name),
                 Expr::Quote { ref string } => write!(fmt, "'{}'", string),
                 Expr::Const { ref value } => {
                     let (_exact, val) = value.to_string(10, Digits::Default);

--- a/core/src/ast/expr.rs
+++ b/core/src/ast/expr.rs
@@ -10,6 +10,7 @@ use serde_derive::Serialize;
 #[serde(tag = "type")]
 pub enum Expr {
     Unit { name: String },
+    Dependency { name: String },
     Quote { string: String },
     Const { value: Numeric },
     Date { tokens: Vec<DateToken> },
@@ -32,6 +33,10 @@ impl Expr {
 
     pub fn new_unit(name: String) -> Expr {
         Expr::Unit { name }
+    }
+
+    pub fn new_dependency(name: String) -> Expr {
+        Expr::Dependency { name }
     }
 
     pub fn new_call(func: Function, args: Vec<Expr>) -> Expr {
@@ -147,6 +152,7 @@ impl fmt::Display for Expr {
         fn recurse(expr: &Expr, fmt: &mut fmt::Formatter<'_>, prec: Precedence) -> fmt::Result {
             match *expr {
                 Expr::Unit { ref name } => write!(fmt, "{}", name),
+                Expr::Dependency { ref name } => write!(fmt, "dependency {}", name),
                 Expr::Quote { ref string } => write!(fmt, "'{}'", string),
                 Expr::Const { ref value } => {
                     let (_exact, val) = value.to_string(10, Digits::Default);

--- a/core/src/commands/search.rs
+++ b/core/src/commands/search.rs
@@ -2,11 +2,9 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-use crate::{
-    loader::Context,
-    output::{NumberParts, SearchReply},
-    types::{BaseUnit, Dimensionality},
-};
+use crate::loader::Context;
+use crate::output::{NumberParts, SearchReply};
+use crate::types::{BaseUnit, Dimensionality};
 
 pub(crate) fn search_internal<'a>(
     ctx: &'a Context,
@@ -28,6 +26,7 @@ pub fn search(ctx: &Context, query: &str, num_results: usize) -> SearchReply {
             .map(|name| {
                 let parts = ctx
                     .lookup(name)
+                    .and_then(|v| v.to_number())
                     .map(|x| x.to_parts(ctx))
                     .or_else(|| {
                         if ctx.registry.substances.get(name).is_some() {

--- a/core/src/helpers.rs
+++ b/core/src/helpers.rs
@@ -2,12 +2,10 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-use crate::{
-    output::{QueryError, QueryReply},
-    parsing::text_query,
-    types::DateTime,
-    Context,
-};
+use crate::output::{QueryError, QueryReply};
+use crate::parsing::text_query;
+use crate::types::DateTime;
+use crate::{Context, Value};
 
 /// The default `definitions.units` file that contains all of the base
 /// units, units, prefixes, quantities, and substances.
@@ -56,7 +54,7 @@ pub fn eval(ctx: &mut Context, line: &str) -> Result<QueryReply, QueryError> {
     if ctx.save_previous_result {
         if let QueryReply::Number(ref number_parts) = res {
             if let Some(ref raw) = number_parts.raw_value {
-                ctx.previous_result = Some(raw.clone());
+                ctx.previous_result = Some(Value::Number(raw.clone()));
             }
         }
     }

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -54,7 +54,7 @@
 //! // enabled. Otherwise, you'll need to install and load this file
 //! // yourself.
 //! let base_defs = rink_core::CURRENCY_FILE.expect("bundle-files feature to be enabled");
-//! ctx.load_currency(&live_data, base_defs)?;
+//! ctx.load_currency(Some(&live_data), base_defs)?;
 //!
 //! println!("{}", rink_core::one_line(&mut ctx, "USD").unwrap());
 //! // Definition: USD = (1 / 1.0843) EUR = approx. 922.2539 millieuro (money; EUR).
@@ -62,6 +62,10 @@
 //! # Ok(())
 //! # }
 //! ```
+//!
+//! If `None` is passed as the live data, then attempting to use any currency
+//! units will return `QueryError::MissingDeps` to indicate that currency data
+//! needs fetching.
 //!
 //! ## Markup
 //!

--- a/core/src/loader/context.rs
+++ b/core/src/loader/context.rs
@@ -29,7 +29,7 @@ pub struct Context {
     /// as the `ans` variable.
     pub save_previous_result: bool,
     /// The previous query result.
-    pub previous_result: Option<Number>,
+    pub previous_result: Option<Value>,
 }
 
 impl Default for Context {
@@ -67,12 +67,12 @@ impl Context {
 
     /// Given a unit name, returns its value if it exists. Supports SI
     /// prefixes, plurals, bare dimensions like length, and quantities.
-    pub fn lookup(&self, name: &str) -> Option<Number> {
+    pub fn lookup(&self, name: &str) -> Option<Value> {
         if name == "ans" || name == "ANS" || name == "_" {
             return self.previous_result.clone();
         }
         if let Some(v) = self.temporaries.get(name).cloned() {
-            return Some(v);
+            return Some(Value::Number(v));
         }
 
         self.registry.lookup(name)

--- a/core/src/loader/context.rs
+++ b/core/src/loader/context.rs
@@ -212,15 +212,19 @@ impl Context {
     // the `bundle-files` feature is enabled. Otherwise, it needs to be
     // installed on the system somewhere and loaded.
     #[cfg(feature = "serde_json")]
-    pub fn load_currency(&mut self, live_data: &str, currency_units: &str) -> Result<(), String> {
-        let mut base_defs = crate::loader::gnu_units::parse_str(currency_units);
-        let mut live_defs: Vec<crate::ast::DefEntry> =
-            serde_json::from_str(&live_data).map_err(|err| format!("{}", err))?;
+    pub fn load_currency(
+        &mut self,
+        live_data: Option<&str>,
+        currency_units: &str,
+    ) -> Result<(), String> {
+        if let Some(live_data) = live_data {
+            let live_defs = serde_json::from_str(&live_data).map_err(|err| format!("{}", err))?;
+            self.load(live_defs)?;
+        };
 
-        let mut defs = vec![];
-        defs.append(&mut base_defs.defs);
-        defs.append(&mut live_defs);
-        self.load(crate::ast::Defs { defs })
+        let base_defs = crate::loader::gnu_units::parse_str(currency_units);
+        self.load(base_defs)?;
+        Ok(())
     }
 
     /// Evaluates an expression to compute its value, *excluding* `->`

--- a/core/src/loader/gnu_units.rs
+++ b/core/src/loader/gnu_units.rs
@@ -9,7 +9,7 @@ use std::iter::Peekable;
 use std::rc::Rc;
 use std::str::Chars;
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub enum Token {
     Eof,
     Newline,
@@ -176,7 +176,11 @@ impl<'a> Iterator for TokenIterator<'a> {
                 }
                 Token::Ident(buf)
             }
-            x if is_ident(x) => {
+            x => {
+                // All of the is_ident==false patterns should have already been handled. This can
+                // be verified by adding all of the is_ident=false patterns as a branch and seeing
+                // that it is unreachable.
+                assert!(is_ident(x));
                 let mut buf = String::new();
                 buf.push(x);
                 while let Some(c) = self.0.peek().cloned() {
@@ -188,7 +192,6 @@ impl<'a> Iterator for TokenIterator<'a> {
                 }
                 Token::Ident(buf)
             }
-            x => Token::Error(format!("Unknown character: '{}'", x)),
         };
         Some(res)
     }
@@ -484,11 +487,11 @@ pub fn parse(iter: &mut Iter<'_>) -> (Defs, Vec<String>) {
                                     let input_name = match iter.next().unwrap() {
                                         Token::Ident(name) => name,
                                         x => {
-                                            println!(
+                                            errors.push(format!(
                                                 "Expected property input \
                                                  name, got {:?}",
                                                 x
-                                            );
+                                            ));
                                             break;
                                         }
                                     };

--- a/core/src/loader/gnu_units.rs
+++ b/core/src/loader/gnu_units.rs
@@ -308,15 +308,6 @@ pub fn parse_expr(iter: &mut Iter<'_>) -> Expr {
     parse_add(iter)
 }
 
-fn is_dependency_kw(token: Option<&Token>) -> bool {
-    if let Some(Token::Ident(id)) = token {
-        if id == "dependency" {
-            return true;
-        }
-    }
-    false
-}
-
 pub fn parse(iter: &mut Iter<'_>) -> Defs {
     let mut map = vec![];
     let mut line = 1;
@@ -355,6 +346,21 @@ pub fn parse(iter: &mut Iter<'_>) -> Defs {
                         }
                         _ => println!("Malformed symbol directive"),
                     }
+                }
+                Token::Ident(ref s) if s == "dependency" => {
+                    let name = if let Some(Token::Ident(ref name)) = iter.next() {
+                        name.clone()
+                    } else {
+                        println!("Expected ident after `!dependency`");
+                        continue;
+                    };
+
+                    map.push(DefEntry {
+                        name: name.clone(),
+                        def: Rc::new(Def::Dependency { name }),
+                        doc: doc.take(),
+                        category: category.clone(),
+                    });
                 }
                 Token::Ident(ref s) => {
                     println!("Unknown directive !{s}");
@@ -441,22 +447,6 @@ pub fn parse(iter: &mut Iter<'_>) -> Defs {
                             def: Rc::new(Def::Quantity {
                                 expr: ExprString(expr),
                             }),
-                            doc: doc.take(),
-                            category: category.clone(),
-                        });
-                    } else if is_dependency_kw(iter.peek()) {
-                        iter.next();
-                        let name = if let Some(Token::Ident(ref name)) = iter.peek().cloned() {
-                            iter.next();
-                            name.clone()
-                        } else {
-                            println!("Expected ident after `dependency`");
-                            continue;
-                        };
-
-                        map.push(DefEntry {
-                            name: name.clone(),
-                            def: Rc::new(Def::Dependency { name }),
                             doc: doc.take(),
                             category: category.clone(),
                         });

--- a/core/src/loader/gnu_units.rs
+++ b/core/src/loader/gnu_units.rs
@@ -308,12 +308,13 @@ pub fn parse_expr(iter: &mut Iter<'_>) -> Expr {
     parse_add(iter)
 }
 
-pub fn parse(iter: &mut Iter<'_>) -> Defs {
+pub fn parse(iter: &mut Iter<'_>) -> (Defs, Vec<String>) {
     let mut map = vec![];
     let mut line = 1;
     let mut doc: Option<String> = None;
     let mut category: Option<String> = None;
     let mut symbols = BTreeMap::new();
+    let mut errors = vec![];
     loop {
         match iter.next().unwrap() {
             Token::Newline => line += 1,
@@ -330,12 +331,12 @@ pub fn parse(iter: &mut Iter<'_>) -> Defs {
                             });
                             category = Some(short);
                         }
-                        _ => println!("Malformed category directive"),
+                        _ => errors.push(format!("Malformed category directive")),
                     }
                 }
                 Token::Ident(ref s) if s == "endcategory" => {
                     if category.is_none() {
-                        println!("Stray endcategory directive");
+                        errors.push(format!("Stray endcategory directive"));
                     }
                     category = None
                 }
@@ -344,14 +345,14 @@ pub fn parse(iter: &mut Iter<'_>) -> Defs {
                         (Token::Ident(subst), Token::Ident(sym)) => {
                             symbols.insert(subst, sym);
                         }
-                        _ => println!("Malformed symbol directive"),
+                        _ => errors.push(format!("Malformed symbol directive")),
                     }
                 }
                 Token::Ident(ref s) if s == "dependency" => {
                     let name = if let Some(Token::Ident(ref name)) = iter.next() {
                         name.clone()
                     } else {
-                        println!("Expected ident after `!dependency`");
+                        errors.push(format!("Expected ident after `!dependency`"));
                         continue;
                     };
 
@@ -363,7 +364,7 @@ pub fn parse(iter: &mut Iter<'_>) -> Defs {
                     });
                 }
                 Token::Ident(ref s) => {
-                    println!("Unknown directive !{s}");
+                    errors.push(format!("Unknown directive !{s}"));
                     loop {
                         match iter.peek().cloned().unwrap() {
                             Token::Newline | Token::Eof => break,
@@ -374,7 +375,7 @@ pub fn parse(iter: &mut Iter<'_>) -> Defs {
                     }
                 }
                 _ => {
-                    println!("syntax error: expected ident after !");
+                    errors.push(format!("syntax error: expected ident after !"));
                     loop {
                         match iter.peek().cloned().unwrap() {
                             Token::Newline | Token::Eof => break,
@@ -474,7 +475,7 @@ pub fn parse(iter: &mut Iter<'_>) -> Defs {
                                 }
                                 Token::RightBrace => break,
                                 x => {
-                                    println!("Expected property, got {:?}", x);
+                                    errors.push(format!("Expected property, got {:?}", x));
                                     break;
                                 }
                             };
@@ -504,7 +505,8 @@ pub fn parse(iter: &mut Iter<'_>) -> Defs {
                                 }
                                 Token::Ident(name) => name,
                                 x => {
-                                    println!("Expected property input name, got {:?}", x);
+                                    errors
+                                        .push(format!("Expected property input name, got {:?}", x));
                                     break;
                                 }
                             };
@@ -512,14 +514,15 @@ pub fn parse(iter: &mut Iter<'_>) -> Defs {
                             match iter.next().unwrap() {
                                 Token::Slash => (),
                                 x => {
-                                    println!("Expected /, got {:?}", x);
+                                    errors.push(format!("Expected /, got {:?}", x));
                                     break;
                                 }
                             }
                             let input_name = match iter.next().unwrap() {
                                 Token::Ident(name) => name,
                                 x => {
-                                    println!("Expected property input name, got {:?}", x);
+                                    errors
+                                        .push(format!("Expected property input name, got {:?}", x));
                                     break;
                                 }
                             };
@@ -556,7 +559,7 @@ pub fn parse(iter: &mut Iter<'_>) -> Defs {
                     }
                 }
             }
-            x => println!("Expected definition on line {}, got {:?}", line, x),
+            x => errors.push(format!("Expected definition on line {}, got {:?}", line, x)),
         };
     }
 
@@ -566,12 +569,16 @@ pub fn parse(iter: &mut Iter<'_>) -> Defs {
         }
     }
 
-    Defs { defs: map }
+    (Defs { defs: map }, errors)
 }
 
 pub fn parse_str(input: &str) -> Defs {
     let mut iter = TokenIterator::new(&*input).peekable();
-    parse(&mut iter)
+    let (defs, errors) = parse(&mut iter);
+    for error in errors {
+        println!("{}", error);
+    }
+    defs
 }
 
 pub fn tokens(iter: &mut Iter<'_>) -> Vec<Token> {
@@ -583,89 +590,4 @@ pub fn tokens(iter: &mut Iter<'_>) -> Vec<Token> {
         }
     }
     out
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    fn do_parse(s: &str) -> Expr {
-        let mut iter = TokenIterator::new(s).peekable();
-        parse_term(&mut iter)
-    }
-
-    macro_rules! expect {
-        ($expr:expr, $pattern:pat, $var:ident, $expected:expr) => {
-            match do_parse($expr) {
-                $pattern => assert_eq!($var, $expected),
-                x => panic!("{}", x),
-            }
-        };
-    }
-
-    #[test]
-    fn test_parse_term_plus() {
-        let expr = do_parse("+1");
-
-        if let Expr::UnaryOp(UnaryOpExpr {
-            op: UnaryOpType::Positive,
-            expr: x,
-        }) = expr
-        {
-            if let Expr::Const { value: x } = *x {
-                if x != 1.into() {
-                    panic!("number != 1");
-                }
-            } else {
-                panic!("argument of x is not Expr::new_const");
-            }
-        } else {
-            panic!("missing plus");
-        }
-    }
-
-    #[test]
-    fn test_missing_bracket() {
-        expect!("(", Expr::Error { ref message }, message, "Expected ), got Eof");
-    }
-
-    #[test]
-    fn test_escapes() {
-        expect!(
-            "\\\r",
-            Expr::Error { ref message },
-            message,
-            "Expected term, got Error(\"Expected LF or CRLF line endings\")"
-        );
-        expect!("\\\r\n1", Expr::Const { value }, value, Numeric::from(1));
-
-        expect!(
-            "\\a",
-            Expr::Error { ref message },
-            message,
-            "Expected term, got Error(\"Invalid escape: \\\\a\")"
-        );
-        expect!(
-            "\\",
-            Expr::Error { ref message },
-            message,
-            "Expected term, got Error(\"Unexpected EOF\")"
-        );
-    }
-
-    #[test]
-    fn test_float_leading_dot() {
-        use crate::types::BigRat;
-        expect!(
-            ".123",
-            Expr::Const { value },
-            value,
-            Numeric::Rational(BigRat::small_ratio(123, 1000))
-        );
-    }
-
-    #[test]
-    fn test_escaped_quotes() {
-        expect!("\"ab\\\"\"", Expr::Unit { ref name }, name, "ab\"")
-    }
 }

--- a/core/src/loader/gnu_units.rs
+++ b/core/src/loader/gnu_units.rs
@@ -308,6 +308,15 @@ pub fn parse_expr(iter: &mut Iter<'_>) -> Expr {
     parse_add(iter)
 }
 
+fn is_dependency_kw(token: Option<&Token>) -> bool {
+    if let Some(Token::Ident(id)) = token {
+        if id == "dependency" {
+            return true;
+        }
+    }
+    false
+}
+
 pub fn parse(iter: &mut Iter<'_>) -> Defs {
     let mut map = vec![];
     let mut line = 1;
@@ -432,6 +441,22 @@ pub fn parse(iter: &mut Iter<'_>) -> Defs {
                             def: Rc::new(Def::Quantity {
                                 expr: ExprString(expr),
                             }),
+                            doc: doc.take(),
+                            category: category.clone(),
+                        });
+                    } else if is_dependency_kw(iter.peek()) {
+                        iter.next();
+                        let name = if let Some(Token::Ident(ref name)) = iter.peek().cloned() {
+                            iter.next();
+                            name.clone()
+                        } else {
+                            println!("Expected ident after `dependency`");
+                            continue;
+                        };
+
+                        map.push(DefEntry {
+                            name: name.clone(),
+                            def: Rc::new(Def::Dependency { name }),
                             doc: doc.take(),
                             category: category.clone(),
                         });

--- a/core/src/loader/registry.rs
+++ b/core/src/loader/registry.rs
@@ -57,11 +57,12 @@ impl Registry {
         if let Some(v) = self.lookup_exact(name) {
             return Some(v);
         }
-        for &(ref pre, ref value) in &self.prefixes {
-            if name.starts_with(pre) {
-                if let Some(Value::Number(v)) = self.lookup_exact(&name[pre.len()..]) {
-                    return Some(Value::Number((&v * &Number::new(value.clone())).unwrap()));
-                }
+        for &(ref pre, ref pre_value) in &self.prefixes {
+            if !name.starts_with(pre) {
+                continue;
+            }
+            if let Some(v) = self.lookup_exact(&name[pre.len()..]) {
+                return Some((&v * &Value::Number(Number::new(pre_value.clone()))).unwrap());
             }
         }
         None

--- a/core/src/loader/registry.rs
+++ b/core/src/loader/registry.rs
@@ -1,11 +1,9 @@
+use crate::ast::{DatePattern, Expr};
+use crate::output::DocString;
+use crate::runtime::Substance;
+use crate::types::{BaseUnit, Dimensionality, Number, Numeric};
+use crate::Value;
 use std::collections::{BTreeMap, BTreeSet};
-
-use crate::{
-    ast::{DatePattern, Expr},
-    output::DocString,
-    runtime::Substance,
-    types::{BaseUnit, Dimensionality, Number, Numeric},
-};
 
 #[derive(Default, Debug)]
 pub struct Registry {
@@ -40,31 +38,31 @@ pub struct Registry {
 }
 
 impl Registry {
-    fn lookup_exact(&self, name: &str) -> Option<Number> {
+    fn lookup_exact(&self, name: &str) -> Option<Value> {
         if let Some(k) = self.base_units.get(name) {
-            return Some(Number::one_unit(k.to_owned()));
+            return Some(Value::Number(Number::one_unit(k.to_owned())));
         }
         if let Some(v) = self.units.get(name).cloned() {
-            return Some(v);
+            return Some(Value::Number(v));
         }
         None
     }
 
-    fn lookup_with_prefix(&self, name: &str) -> Option<Number> {
+    fn lookup_with_prefix(&self, name: &str) -> Option<Value> {
         if let Some(v) = self.lookup_exact(name) {
             return Some(v);
         }
         for &(ref pre, ref value) in &self.prefixes {
             if name.starts_with(pre) {
-                if let Some(v) = self.lookup_exact(&name[pre.len()..]) {
-                    return Some((&v * &Number::new(value.clone())).unwrap());
+                if let Some(Value::Number(v)) = self.lookup_exact(&name[pre.len()..]) {
+                    return Some(Value::Number((&v * &Number::new(value.clone())).unwrap()));
                 }
             }
         }
         None
     }
 
-    pub(crate) fn lookup(&self, name: &str) -> Option<Number> {
+    pub(crate) fn lookup(&self, name: &str) -> Option<Value> {
         let res = self.lookup_with_prefix(name);
         if res.is_some() {
             return res;

--- a/core/src/output/reply.rs
+++ b/core/src/output/reply.rs
@@ -191,7 +191,6 @@ impl ExprReply {
             }
             match *expr {
                 Expr::Unit { ref name } => parts.push(ExprParts::Unit { name: name.clone() }),
-                Expr::Dependency { ref name } => literal!(format!("dependency {name}")),
                 Expr::Quote { ref string } => literal!(format!("'{}'", string)),
                 Expr::Const { ref value } => {
                     let (_exact, val) = value.to_string(10, Digits::Default);

--- a/core/src/runtime/eval.rs
+++ b/core/src/runtime/eval.rs
@@ -14,7 +14,6 @@ use crate::output::{
     UnitsForReply, UnitsInCategory,
 };
 use crate::parsing::{datetime, formula};
-use crate::runtime::MissingDeps;
 use crate::types::{BaseUnit, BigInt, Dimensionality, Number, Numeric};
 use std::collections::BTreeMap;
 use std::convert::TryFrom;
@@ -81,9 +80,6 @@ pub(crate) fn eval_expr(ctx: &Context, expr: &Expr) -> Result<Value, QueryError>
                 .map(Value::Substance)
             })
             .ok_or_else(|| QueryError::NotFound(ctx.unknown_unit_err(name))),
-        Expr::Dependency { ref name } => Ok(
-            lookup_unit(ctx, name).unwrap_or_else(|| Value::MissingDeps(MissingDeps::new(name)))
-        ),
         Expr::Quote { ref string } => Ok(Value::Number(Number::one_unit(BaseUnit::new(string)))),
         Expr::Const { ref value } => Ok(Value::Number(Number::new(value.clone()))),
         Expr::Date { ref tokens } => match datetime::try_decode(tokens, ctx) {
@@ -471,9 +467,6 @@ pub fn eval_unit_name(
     match *expr {
         Expr::Call { .. } => Err(QueryError::generic(
             "Calls are not allowed in the right hand side of conversions".to_string(),
-        )),
-        Expr::Dependency { .. } => Err(QueryError::generic(
-            "Dependencies are not allowed in the right hand side of conversions".to_string(),
         )),
         Expr::Unit { ref name } | Expr::Quote { string: ref name } => {
             let mut map = BTreeMap::new();

--- a/core/src/runtime/mod.rs
+++ b/core/src/runtime/mod.rs
@@ -12,4 +12,5 @@ pub(crate) use eval::{eval_expr, eval_query};
 pub(crate) use value::Show;
 
 pub use substance::{Properties, Property, Substance, SubstanceGetError};
+pub use value::MissingDeps;
 pub use value::Value;

--- a/core/src/runtime/value.rs
+++ b/core/src/runtime/value.rs
@@ -49,6 +49,22 @@ impl Value {
             (_, _) => Err("Operation is not defined".to_string()),
         }
     }
+
+    pub fn as_number(&self) -> Option<&Number> {
+        if let Value::Number(ref num) = self {
+            Some(num)
+        } else {
+            None
+        }
+    }
+
+    pub fn to_number(&self) -> Option<Number> {
+        if let Value::Number(ref num) = self {
+            Some(num.clone())
+        } else {
+            None
+        }
+    }
 }
 
 impl<'a, 'b> Add<&'b Value> for &'a Value {

--- a/core/tests/canonicalize.rs
+++ b/core/tests/canonicalize.rs
@@ -14,7 +14,9 @@ fn canonicalizations() {
         };
         let cvalue = ctx
             .lookup(&*canon)
-            .expect(&*format!("Failed to lookup {}", canon));
+            .expect(&*format!("Failed to lookup {}", canon))
+            .to_number()
+            .expect("should have been number");
         assert_eq!(cvalue, *value, "{} == {}", name, canon);
     }
 }

--- a/core/tests/currency_loading.rs
+++ b/core/tests/currency_loading.rs
@@ -3,7 +3,7 @@ fn load_currency() {
     let mut ctx = rink_core::simple_context().unwrap();
     let live_data = include_str!("../tests/currency.snapshot.json");
     let base_defs = rink_core::CURRENCY_FILE.unwrap();
-    ctx.load_currency(&live_data, base_defs).unwrap();
+    ctx.load_currency(Some(&live_data), base_defs).unwrap();
 
     let result = rink_core::one_line(&mut ctx, "USD");
     assert_eq!(

--- a/core/tests/currency_loading.rs
+++ b/core/tests/currency_loading.rs
@@ -1,5 +1,6 @@
 #[test]
-fn load_currency() {
+#[cfg(feature = "serde_json")]
+fn load_currency_with_live_data() {
     let mut ctx = rink_core::simple_context().unwrap();
     let live_data = include_str!("../tests/currency.snapshot.json");
     let base_defs = rink_core::CURRENCY_FILE.unwrap();
@@ -14,4 +15,36 @@ fn load_currency() {
             Current as of 2024-05-31."
             .to_owned())
     );
+}
+
+#[test]
+#[cfg(feature = "serde_json")]
+fn load_currency_without_live_data() {
+    let mut ctx = rink_core::simple_context().unwrap();
+    let base_defs = rink_core::CURRENCY_FILE.unwrap();
+    ctx.load_currency(None, base_defs).unwrap();
+
+    // Direct
+    let result = rink_core::one_line(&mut ctx, "USD");
+    assert_eq!(result, Err("Missing dependencies: USD".to_owned()));
+
+    // Alias
+    let result = rink_core::one_line(&mut ctx, "$");
+    assert_eq!(result, Err("Missing dependencies: USD".to_owned()));
+
+    // Derived unit
+    let result = rink_core::one_line(&mut ctx, "cent");
+    assert_eq!(result, Err("Missing dependencies: USD".to_owned()));
+
+    // Direct
+    let result = rink_core::one_line(&mut ctx, "bitcoin");
+    assert_eq!(result, Err("Missing dependencies: bitcoin".to_owned()));
+
+    // Alias
+    let result = rink_core::one_line(&mut ctx, "BTC");
+    assert_eq!(result, Err("Missing dependencies: BTC".to_owned()));
+
+    // Prefix
+    let result = rink_core::one_line(&mut ctx, "mBTC");
+    assert_eq!(result, Err("Missing dependencies: BTC".to_owned()));
 }

--- a/core/tests/currency_loading.rs
+++ b/core/tests/currency_loading.rs
@@ -55,4 +55,85 @@ fn load_currency_without_live_data() {
     // Unit list with missing dep in list only
     let result = rink_core::one_line(&mut ctx, "EUR to $, cent");
     assert_eq!(result, Err("Missing dependencies: USD".into()));
+
+    // Operators
+    let result = rink_core::one_line(&mut ctx, "£ + $");
+    assert_eq!(result, Err("Missing dependencies: GBP, USD".into()));
+    let result = rink_core::one_line(&mut ctx, "€ + $");
+    assert_eq!(result, Err("Missing dependencies: USD".into()));
+    let result = rink_core::one_line(&mut ctx, "$ + €");
+    assert_eq!(result, Err("Missing dependencies: USD".into()));
+
+    let result = rink_core::one_line(&mut ctx, "£ - $");
+    assert_eq!(result, Err("Missing dependencies: GBP, USD".into()));
+    let result = rink_core::one_line(&mut ctx, "€ - $");
+    assert_eq!(result, Err("Missing dependencies: USD".into()));
+    let result = rink_core::one_line(&mut ctx, "$ - €");
+    assert_eq!(result, Err("Missing dependencies: USD".into()));
+
+    let result = rink_core::one_line(&mut ctx, "£ * $");
+    assert_eq!(result, Err("Missing dependencies: GBP, USD".into()));
+    let result = rink_core::one_line(&mut ctx, "€ * $");
+    assert_eq!(result, Err("Missing dependencies: USD".into()));
+    let result = rink_core::one_line(&mut ctx, "$ * €");
+    assert_eq!(result, Err("Missing dependencies: USD".into()));
+
+    let result = rink_core::one_line(&mut ctx, "£ / $");
+    assert_eq!(result, Err("Missing dependencies: GBP, USD".into()));
+    let result = rink_core::one_line(&mut ctx, "€ / $");
+    assert_eq!(result, Err("Missing dependencies: USD".into()));
+    let result = rink_core::one_line(&mut ctx, "$ / €");
+    assert_eq!(result, Err("Missing dependencies: USD".into()));
+
+    let result = rink_core::one_line(&mut ctx, "£ ^ $");
+    assert_eq!(result, Err("Missing dependencies: GBP, USD".into()));
+    let result = rink_core::one_line(&mut ctx, "€ ^ $");
+    assert_eq!(result, Err("Missing dependencies: USD".into()));
+    let result = rink_core::one_line(&mut ctx, "$ ^ €");
+    assert_eq!(result, Err("Missing dependencies: USD".into()));
+
+    let result = rink_core::one_line(&mut ctx, "£ << $");
+    assert_eq!(result, Err("Missing dependencies: GBP, USD".into()));
+    let result = rink_core::one_line(&mut ctx, "€ << $");
+    assert_eq!(result, Err("Missing dependencies: USD".into()));
+    let result = rink_core::one_line(&mut ctx, "$ << €");
+    assert_eq!(result, Err("Missing dependencies: USD".into()));
+
+    let result = rink_core::one_line(&mut ctx, "£ >> $");
+    assert_eq!(result, Err("Missing dependencies: GBP, USD".into()));
+    let result = rink_core::one_line(&mut ctx, "€ >> $");
+    assert_eq!(result, Err("Missing dependencies: USD".into()));
+    let result = rink_core::one_line(&mut ctx, "$ >> €");
+    assert_eq!(result, Err("Missing dependencies: USD".into()));
+
+    let result = rink_core::one_line(&mut ctx, "£ mod $");
+    assert_eq!(result, Err("Missing dependencies: GBP, USD".into()));
+    let result = rink_core::one_line(&mut ctx, "€ mod $");
+    assert_eq!(result, Err("Missing dependencies: USD".into()));
+    let result = rink_core::one_line(&mut ctx, "$ mod €");
+    assert_eq!(result, Err("Missing dependencies: USD".into()));
+
+    let result = rink_core::one_line(&mut ctx, "£ and $");
+    assert_eq!(result, Err("Missing dependencies: GBP, USD".into()));
+    let result = rink_core::one_line(&mut ctx, "€ and $");
+    assert_eq!(result, Err("Missing dependencies: USD".into()));
+    let result = rink_core::one_line(&mut ctx, "$ and €");
+    assert_eq!(result, Err("Missing dependencies: USD".into()));
+
+    let result = rink_core::one_line(&mut ctx, "£ xor $");
+    assert_eq!(result, Err("Missing dependencies: GBP, USD".into()));
+    let result = rink_core::one_line(&mut ctx, "€ xor $");
+    assert_eq!(result, Err("Missing dependencies: USD".into()));
+    let result = rink_core::one_line(&mut ctx, "$ xor €");
+    assert_eq!(result, Err("Missing dependencies: USD".into()));
+
+    let result = rink_core::one_line(&mut ctx, "£ or $");
+    assert_eq!(result, Err("Missing dependencies: GBP, USD".into()));
+    let result = rink_core::one_line(&mut ctx, "€ or $");
+    assert_eq!(result, Err("Missing dependencies: USD".into()));
+    let result = rink_core::one_line(&mut ctx, "$ or €");
+    assert_eq!(result, Err("Missing dependencies: USD".into()));
+
+    let result = rink_core::one_line(&mut ctx, "-£");
+    assert_eq!(result, Err("Missing dependencies: GBP".into()));
 }

--- a/core/tests/currency_loading.rs
+++ b/core/tests/currency_loading.rs
@@ -47,4 +47,12 @@ fn load_currency_without_live_data() {
     // Prefix
     let result = rink_core::one_line(&mut ctx, "mBTC");
     assert_eq!(result, Err("Missing dependencies: BTC".to_owned()));
+
+    // Unit list conversion
+    let result = rink_core::one_line(&mut ctx, "5.5$ to $, cent");
+    assert_eq!(result, Err("Missing dependencies: USD".into()));
+
+    // Unit list with missing dep in list only
+    let result = rink_core::one_line(&mut ctx, "EUR to $, cent");
+    assert_eq!(result, Err("Missing dependencies: USD".into()));
 }

--- a/core/tests/gnu_units.rs
+++ b/core/tests/gnu_units.rs
@@ -1,0 +1,146 @@
+use std::rc::Rc;
+
+use rink_core::ast::{Def, DefEntry, Defs, Expr, UnaryOpExpr, UnaryOpType};
+use rink_core::loader::gnu_units::{parse, parse_expr, TokenIterator};
+use rink_core::types::{BigRat, Numeric};
+
+fn do_parse_expr(s: &str) -> Expr {
+    let mut iter = TokenIterator::new(s).peekable();
+    parse_expr(&mut iter)
+}
+
+fn do_parse(s: &str) -> (Defs, Vec<String>) {
+    let mut iter = TokenIterator::new(s).peekable();
+    parse(&mut iter)
+}
+
+#[test]
+fn test_parse_term_plus() {
+    let expr = do_parse_expr("+1");
+
+    if let Expr::UnaryOp(UnaryOpExpr {
+        op: UnaryOpType::Positive,
+        expr: x,
+    }) = expr
+    {
+        if let Expr::Const { value: x } = *x {
+            if x != 1.into() {
+                panic!("number != 1");
+            }
+        } else {
+            panic!("argument of x is not Expr::new_const");
+        }
+    } else {
+        panic!("missing plus");
+    }
+}
+
+#[test]
+fn test_missing_bracket() {
+    assert_eq!(
+        do_parse_expr("("),
+        Expr::Error {
+            message: "Expected ), got Eof".into()
+        }
+    );
+}
+
+#[test]
+fn test_escapes() {
+    assert_eq!(
+        do_parse_expr("\\\r"),
+        Expr::Error {
+            message: "Expected term, got Error(\"Expected LF or CRLF line endings\")".into()
+        }
+    );
+    assert_eq!(
+        do_parse_expr("\\\r\n1"),
+        Expr::Const {
+            value: Numeric::from(1)
+        }
+    );
+    assert_eq!(
+        do_parse_expr("\\a"),
+        Expr::Error {
+            message: "Expected term, got Error(\"Invalid escape: \\\\a\")".into(),
+        },
+    );
+    assert_eq!(
+        do_parse_expr("\\"),
+        Expr::Error {
+            message: "Expected term, got Error(\"Unexpected EOF\")".into()
+        }
+    );
+}
+
+#[test]
+fn test_float_leading_dot() {
+    assert_eq!(
+        do_parse_expr(".123"),
+        Expr::Const {
+            value: Numeric::Rational(BigRat::small_ratio(123, 1000))
+        }
+    );
+}
+
+#[test]
+fn test_escaped_quotes() {
+    assert_eq!(
+        do_parse_expr("\"ab\\\"\""),
+        Expr::Unit {
+            name: "ab\"".into()
+        }
+    );
+}
+
+#[test]
+fn test_category_directive() {
+    let (defs, errors) = do_parse("!category short long");
+    assert_eq!(errors, Vec::<String>::new());
+    assert_eq!(
+        defs.defs,
+        vec![DefEntry {
+            name: "short".into(),
+            def: Rc::new(Def::Category {
+                display_name: "long".into()
+            }),
+            doc: None,
+            category: None,
+        }]
+    );
+    let (defs, errors) = do_parse("!category");
+    assert_eq!(defs.defs, vec![]);
+    assert_eq!(errors, vec!["Malformed category directive"]);
+}
+
+#[test]
+fn test_dependency_directive() {
+    let (defs, errors) = do_parse("!dependency foo");
+    assert_eq!(errors, Vec::<String>::new());
+    assert_eq!(
+        defs.defs,
+        vec![DefEntry {
+            name: "foo".into(),
+            def: Rc::new(Def::Dependency { name: "foo".into() }),
+            doc: None,
+            category: None,
+        }]
+    );
+    let (defs, errors) = do_parse("!dependency");
+    assert_eq!(defs.defs, vec![]);
+    assert_eq!(errors, vec!["Expected ident after `!dependency`"]);
+}
+
+#[test]
+fn test_unknown_directive() {
+    let (defs, errors) = do_parse("!foo asdf xyz");
+    assert_eq!(errors, vec!["Unknown directive !foo"]);
+    assert_eq!(defs.defs, vec![]);
+}
+
+#[test]
+fn test_invalid_directive() {
+    let (defs, errors) = do_parse("!4 xyz");
+    assert_eq!(errors, vec!["syntax error: expected ident after !"]);
+    assert_eq!(defs.defs, vec![]);
+}

--- a/docs/rink.5.adoc
+++ b/docs/rink.5.adoc
@@ -72,11 +72,10 @@ The `[currency]` section.
 Seting it to `"always"` will download immediately when a currency unit
 is used.
 
-*fetch_on_startup* = <__bool__>::
-	Default: `true`. Despite the name, Rink doesn't fetch currency on
-	startup anymore. Setting this to `false` causes rink to behave as
-	if `cache_duration` was infinite. If the currency file doesn't exist,
-	it will fetch it, otherwise it will use it indefinitely. Rink can be
+*cache_expiration_enabled* = <__bool__>::
+	Default: `true`. Setting this to `false` causes rink to behave as if
+	`cache_duration` was infinite. If the currency file doesn't exist, it
+	will fetch it, otherwise it will use it indefinitely. Rink can be
 	invoked with `--fetch-currency` to download the latest version.
 +
 This setting might be useful for intermittent internet access. You can

--- a/docs/rink.5.adoc
+++ b/docs/rink.5.adoc
@@ -60,16 +60,28 @@ Currency
 The `[currency]` section.
 
 *enabled* = <__bool__>::
-	Currency fetching can be disabled for those that don't want it.
+	Currency support can be disabled entirely. When set to false, the
+	`currency.json` will not be loaded, and trying to use currency units
+	will give a "not found" error.
 	Default: `true`
 
+*behavior* = <__"prompt"__ | _"always"_ | __"disabled"__>::
+	Default: `"prompt"`. When attempting to use a currency unit, Rink will
+	ask if you'd like to download the currency data.
++
+Seting it to `"always"` will download immediately when a currency unit
+is used.
+
 *fetch_on_startup* = <__bool__>::
-	Setting this to `false` causes rink to behave as if
-	`cache_duration` was infinite. If the currency file doesn't
-	exist, it will fetch it, otherwise it will use it indefinitely.
-	Rink can be invoked with `--fetch-currency` to download the
-	latest version.
-	Default: `true`
+	Default: `true`. Despite the name, Rink doesn't fetch currency on
+	startup anymore. Setting this to `false` causes rink to behave as
+	if `cache_duration` was infinite. If the currency file doesn't exist,
+	it will fetch it, otherwise it will use it indefinitely. Rink can be
+	invoked with `--fetch-currency` to download the latest version.
++
+This setting might be useful for intermittent internet access. You can
+setup a cron job to fetch the currency data while the network is up,
+making it available later when using rink offline.
 
 *endpoint* = <__url__>::
 	Allows pointing to alternate Rink-Web instances, or to any other API

--- a/docs/rink.5.adoc
+++ b/docs/rink.5.adoc
@@ -89,7 +89,7 @@ making it available later when using rink offline.
 
 *timeout* = <__duration__>::
 	How long to wait for currency fetching before giving up.
-	Default: `"2s"`
+	Default: `"15s"`
 
 *cache_duration* = <__duration__>::
 	How long to wait before considering the cached currency data stale.

--- a/docs/rink.5.adoc
+++ b/docs/rink.5.adoc
@@ -65,7 +65,7 @@ The `[currency]` section.
 	will give a "not found" error.
 	Default: `true`
 
-*behavior* = <__"prompt"__ | _"always"_ | __"disabled"__>::
+*behavior* = <__"prompt"__ | __"always"__>::
 	Default: `"prompt"`. When attempting to use a currency unit, Rink will
 	ask if you'd like to download the currency data.
 +

--- a/irc/src/config.rs
+++ b/irc/src/config.rs
@@ -76,7 +76,7 @@ fn try_load_currency(config: &Currency, ctx: &mut Context) {
     let base = rink_core::CURRENCY_FILE.unwrap();
     let live = std::fs::read_to_string(&config.path).unwrap();
 
-    ctx.load_currency(&live, &base).unwrap();
+    ctx.load_currency(Some(&live), &base).unwrap();
 }
 
 /// Creates a context by searching standard directories

--- a/rink-js/src/lib.rs
+++ b/rink-js/src/lib.rs
@@ -3,11 +3,11 @@
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
 use js_sys::Date;
-use rink_core::ast;
 use rink_core::output::fmt::{FmtToken, Span, TokenFmt};
 use rink_core::output::QueryReply;
 use rink_core::parsing::text_query;
 use rink_core::types::DateTime;
+use rink_core::{ast, Value};
 use serde_derive::*;
 use wasm_bindgen::prelude::*;
 
@@ -124,7 +124,7 @@ impl Context {
     #[wasm_bindgen(js_name = loadCurrency)]
     pub fn load_currency(&mut self, live_defs: String) -> Result<(), JsValue> {
         let base_defs = rink_core::CURRENCY_FILE.unwrap();
-        self.context.load_currency(&live_defs, base_defs)?;
+        self.context.load_currency(Some(&live_defs), base_defs)?;
 
         Ok(())
     }
@@ -135,7 +135,7 @@ impl Context {
         if self.context.save_previous_result {
             if let Ok(QueryReply::Number(ref number_parts)) = value {
                 if let Some(ref raw) = number_parts.raw_value {
-                    self.context.previous_result = Some(raw.clone());
+                    self.context.previous_result = Some(Value::Number(raw.clone()));
                 }
             }
         }
@@ -152,7 +152,7 @@ impl Context {
         if self.context.save_previous_result {
             if let Ok(QueryReply::Number(ref number_parts)) = value {
                 if let Some(ref raw) = number_parts.raw_value {
-                    self.context.previous_result = Some(raw.clone());
+                    self.context.previous_result = Some(Value::Number(raw.clone()));
                 }
             }
         }


### PR DESCRIPTION
Implements #50 and #193.

I've been wanting to make this change for years but couldn't figure out how to fit it into the existing codebase.

This PR defers currency fetching until the moment you actually try to use currency units. By default, it will prompt to ask whether you want to download the file. It can be set to do this automatically by setting `[currency] behavior = "always"` in the `config.toml`.

```
> 1 + 1
2 (dimensionless)
> 5 cents
Download currency data from <https://rinkcalc.app/data/currency.json>? [y/n] y
Fetched 6kB in 279ms
approx. 42.77891 millieuro (money)
> BTC
Definition: BTC = price of bitcoin = approx. 100.6693 kiloeuro (money; EUR)
```

The behavior is smart:
- If a previous `rink` instance already fetched currency and that cached file hasn't expired, it will be used at startup without prompting.
- It will remember that currency was fetched for the remainder of the session.

The way this is done in `rink-core` is by adding a new `Value::MissingDeps` variant. Dependencies can be declared in the `.units` file without throwing errors if they are not present. Instead, they will be recorded in the Registry. When attempting to use one, it will be surfaced up to the caller. The caller (e.g. the CLI) can then decide how to try to satisfy these missing dependencies and then reload the Context.

## TODO

- [x] Improve test coverage
- [x] Do any remaining code cleanups
- [x] Fix flaky tests
- [x] Test irc and wasm frontends
- [x] Update documentation
- [x] Check error cases
- [x] Make prefixes work (e.g. mBTC)