### PR TITLE
Dependencies cleanup 2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -387,12 +387,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "79296716171880943b8470b5f8d03aa55eb2e645a4874bdbb28adb49162e012c"
 
 [[package]]
-name = "byteorder"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
-
-[[package]]
 name = "bytes"
 version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1861,7 +1855,6 @@ name = "rink-sandbox"
 version = "0.6.1"
 dependencies = [
  "bincode",
- "byteorder",
  "color-eyre 0.5.11",
  "ctrlc",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1866,7 +1866,6 @@ dependencies = [
  "ctrlc",
  "serde",
  "serde_derive",
- "thiserror",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -474,21 +474,6 @@ dependencies = [
 
 [[package]]
 name = "color-eyre"
-version = "0.5.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f1885697ee8a177096d42f158922251a41973117f6d8a234cee94b9509157b7"
-dependencies = [
- "backtrace",
- "color-spantrace",
- "eyre",
- "indenter",
- "once_cell",
- "owo-colors 1.3.0",
- "tracing-error",
-]
-
-[[package]]
-name = "color-eyre"
 version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "55146f5e46f237f7423d74111267d4597b59b0dad0ffaf7303bce9945d843ad5"
@@ -497,19 +482,7 @@ dependencies = [
  "eyre",
  "indenter",
  "once_cell",
- "owo-colors 3.5.0",
-]
-
-[[package]]
-name = "color-spantrace"
-version = "0.1.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6eee477a4a8a72f4addd4de416eb56d54bc307b284d6601bafdee1f4ea462d1"
-dependencies = [
- "once_cell",
- "owo-colors 1.3.0",
- "tracing-core",
- "tracing-error",
+ "owo-colors",
 ]
 
 [[package]]
@@ -1509,12 +1482,6 @@ dependencies = [
 
 [[package]]
 name = "owo-colors"
-version = "1.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2386b4ebe91c2f7f51082d4cefa145d030e33a1842a96b12e4885cc3c01f7a55"
-
-[[package]]
-name = "owo-colors"
 version = "3.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c1b04fb49957986fdce4d6ee7a65027d55d4b6d2265e5848bbb507b58ccfdb6f"
@@ -1779,7 +1746,7 @@ version = "0.8.0"
 dependencies = [
  "assert_cmd",
  "clap",
- "color-eyre 0.6.3",
+ "color-eyre",
  "curl",
  "dirs 4.0.0",
  "eyre",
@@ -1855,7 +1822,6 @@ name = "rink-sandbox"
 version = "0.6.1"
 dependencies = [
  "bincode",
- "color-eyre 0.5.11",
  "ctrlc",
  "serde",
  "serde_derive",
@@ -2031,15 +1997,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "sharded-slab"
-version = "0.1.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
-dependencies = [
- "lazy_static",
-]
-
-[[package]]
 name = "signal-hook-registry"
 version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2168,16 +2125,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
-]
-
-[[package]]
-name = "thread_local"
-version = "1.1.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b9ef9bad013ada3808854ceac7b46812a6465ba368859a37e2100283d2d719c"
-dependencies = [
- "cfg-if 1.0.0",
- "once_cell",
 ]
 
 [[package]]
@@ -2332,19 +2279,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3523ab5a71916ccf420eebdf5521fcef02141234bbc0b8a49f2fdc4544364ef"
 dependencies = [
  "pin-project-lite",
- "tracing-attributes",
  "tracing-core",
-]
-
-[[package]]
-name = "tracing-attributes"
-version = "0.1.27"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
 ]
 
 [[package]]
@@ -2354,28 +2289,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c06d3da6113f116aaee68e4d601191614c9053067f9ab7f6edbcb161237daa54"
 dependencies = [
  "once_cell",
- "valuable",
-]
-
-[[package]]
-name = "tracing-error"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4d7c0b83d4a500748fa5879461652b361edf5c9d51ede2a2ac03875ca185e24"
-dependencies = [
- "tracing",
- "tracing-subscriber",
-]
-
-[[package]]
-name = "tracing-subscriber"
-version = "0.2.25"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e0d2eaa99c3c2e41547cfa109e910a68ea03823cccad4a0525dcbc9b01e8c71"
-dependencies = [
- "sharded-slab",
- "thread_local",
- "tracing-core",
 ]
 
 [[package]]
@@ -2410,12 +2323,6 @@ name = "utf8parse"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "711b9620af191e0cdc7468a8d14e709c3dcdb115b36f838e601583af800a370a"
-
-[[package]]
-name = "valuable"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "830b7e5d4d90034032940e4ace0d9a9a057e7a45cd94e6c007832e39edb82f6d"
 
 [[package]]
 name = "value-bag"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -473,19 +473,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "color-eyre"
-version = "0.6.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55146f5e46f237f7423d74111267d4597b59b0dad0ffaf7303bce9945d843ad5"
-dependencies = [
- "backtrace",
- "eyre",
- "indenter",
- "once_cell",
- "owo-colors",
-]
-
-[[package]]
 name = "colorchoice"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1481,12 +1468,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "owo-colors"
-version = "3.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1b04fb49957986fdce4d6ee7a65027d55d4b6d2265e5848bbb507b58ccfdb6f"
-
-[[package]]
 name = "parking"
 version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1746,7 +1727,6 @@ version = "0.8.0"
 dependencies = [
  "assert_cmd",
  "clap",
- "color-eyre",
  "curl",
  "dirs 4.0.0",
  "eyre",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -24,7 +24,6 @@ serde_derive = "1"
 serde = { version = "1", default-features = false }
 tempfile = "3.2"
 eyre = "0.6"
-color-eyre = { version = "0.6", default-features = false }
 humantime-serde = "1.0.1"
 rustyline = { version = "9", default-features = false }
 nu-ansi-term = "0.50"

--- a/cli/src/config.rs
+++ b/cli/src/config.rs
@@ -4,8 +4,7 @@
 
 use crate::currency::load_cached_currency_if_current;
 use crate::style_ser;
-use color_eyre::Result;
-use eyre::{eyre, WrapErr};
+use eyre::{eyre, Result, WrapErr};
 use nu_ansi_term::{Color, Style};
 use rink_core::loader::gnu_units;
 use rink_core::output::fmt::FmtToken;

--- a/cli/src/currency.rs
+++ b/cli/src/currency.rs
@@ -6,9 +6,8 @@ use std::path::PathBuf;
 use std::time::Duration;
 
 use crate::config::{read_from_search_path, Currency};
-use color_eyre::Result;
 use curl::easy::Easy;
-use eyre::{eyre, Context as _, Report};
+use eyre::{eyre, Context as _, Report, Result};
 use rink_core::{Context, CURRENCY_FILE};
 
 /// Returns path to currency.json

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -65,9 +65,6 @@ fn main() -> Result<ExitCode> {
     if matches.get_flag("service") {
         return service::run_service().map(|_| ExitCode::SUCCESS);
     }
-    // The panic handler can't be installed if entering service mode, so
-    // it's placed after that check.
-    color_eyre::install()?;
     let config = config::read_config(matches.get_one::<String>("config").map(|s| &**s))?;
 
     if let Some(filename) = matches.get_one::<String>("dump") {

--- a/cli/tests/repl.rs
+++ b/cli/tests/repl.rs
@@ -61,3 +61,29 @@ fn test_sandboxed() {
             "No such unit doesnt_exist\nFinished in ",
         ));
 }
+
+// Causes a 100% repro for a bug that causes code coverage to fail.
+// "invalid instrumentation profile data (file header is corrupt)"
+#[test]
+#[ignore]
+fn test_sandboxed_panic_handler() {
+    let mut cmd = Command::cargo_bin("rink").unwrap();
+    cmd.arg("-c")
+        .arg("tests/config_sandboxed.toml")
+        .write_stdin("__super_secret_plz_crash\n")
+        .env("NO_COLOR", "true")
+        .assert()
+        .success()
+        .stdout(
+            predicate::eq(
+                "The subprocess panicked (crashed).
+Message: Thank you for playing Wing Commander
+Location: core/src/runtime/eval.rs:76
+
+Backtrace omitted.
+Run with RUST_BACKTRACE=1 environment variable to display it.
+Run with RUST_BACKTRACE=full to include source snippets.",
+            )
+            .trim(),
+        );
+}

--- a/core/src/runtime/eval.rs
+++ b/core/src/runtime/eval.rs
@@ -71,6 +71,10 @@ pub(crate) fn eval_expr(ctx: &Context, expr: &Expr) -> Result<Value, QueryError>
 
     match *expr {
         Expr::Unit { ref name } if name == "now" => Ok(Value::DateTime(ctx.now.clone())),
+        // Useful for testing the panic handler in rink-sandbox
+        Expr::Unit { ref name } if name == "__super_secret_plz_crash" => {
+            panic!("Thank you for playing Wing Commander")
+        }
         Expr::Unit { ref name } => lookup_unit(ctx, name)
             .or_else(|| {
                 formula::substance_from_formula(

--- a/sandbox/Cargo.toml
+++ b/sandbox/Cargo.toml
@@ -14,7 +14,6 @@ categories = ["command-line-utilities"]
 bincode = "1.3.3"
 serde_derive = "1"
 serde = { version = "1", default-features = false }
-byteorder = { version = "1", default-features = false }
 color-eyre = "0.5"
 ctrlc = "3.4.7"
 

--- a/sandbox/Cargo.toml
+++ b/sandbox/Cargo.toml
@@ -14,7 +14,6 @@ categories = ["command-line-utilities"]
 bincode = "1.3.3"
 serde_derive = "1"
 serde = { version = "1", default-features = false }
-color-eyre = "0.5"
 ctrlc = "3.4.7"
 
 [[test]]

--- a/sandbox/Cargo.toml
+++ b/sandbox/Cargo.toml
@@ -12,7 +12,6 @@ categories = ["command-line-utilities"]
 
 [dependencies]
 bincode = "1.3.3"
-thiserror = "1"
 serde_derive = "1"
 serde = { version = "1", default-features = false }
 byteorder = { version = "1", default-features = false }

--- a/sandbox/src/error.rs
+++ b/sandbox/src/error.rs
@@ -6,25 +6,25 @@ use core::fmt;
 use serde_derive::{Deserialize, Serialize};
 use std::error::Error as StdError;
 use std::io::Error as IoError;
-use std::sync::mpsc::RecvError;
 use std::time::Duration;
 
 /// All of the errors that can result while managing the child process.
 #[derive(Debug)]
 #[non_exhaustive]
 pub enum Error {
-    /// IO error
-    Io(IoError),
-    /// {0}
-    Recv(RecvError),
-    /// Failed to send {0}
-    Send(&'static str),
     /// Timed out after {0:?}
     Timeout(Duration),
-    /// Bincode
-    Bincode(bincode::Error),
     /// Panic: {0}
     Panic(String),
+    /// When starting the child process fails
+    HandshakeFailure(String),
+    /// Child process crashed
+    Crashed,
+    /// Interrupted (Ctrl+C)
+    Interrupted,
+    /// Read channel disconnected (other end hung up)
+    Disconnected,
+
     /// Failed to start child process
     InitFailure(IoError),
     /// Failed to read from child
@@ -35,47 +35,30 @@ pub enum Error {
     CreatePipeFailed(IoError),
     /// Failed to kill child process
     KillFailed(IoError),
-    /// Failed to start child process: {0}
-    HandshakeFailure(String),
-    /// Child process crashed
-    Crashed,
-    /// Interrupted
-    Interrupted,
-    /// Read channel disconnected
-    Disconnected,
+    /// When writing a frame fails
+    SerializeFailed(bincode::Error),
+    /// When reading a frame fails
+    DeserializeFailed(bincode::Error),
 }
 
 impl fmt::Display for Error {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            Error::Io(_) => write!(f, "IO error"),
-            Error::Recv(err) => write!(f, "{}", err),
-            Error::Send(err) => write!(f, "Failed to send {err}"),
-            Error::Timeout(err) => write!(f, "Timed out after {err:?}"),
-            Error::Bincode(_) => write!(f, "Bincode"),
-            Error::Panic(err) => write!(f, "Panic: {err}"),
-            Error::InitFailure(_) => write!(f, "Failed to start child process"),
-            Error::ReadFailed(_) => write!(f, "Failed to read from child"),
-            Error::WriteFailed(_) => write!(f, "Failed to write to child"),
-            Error::CreatePipeFailed(_) => write!(f, "Failed to create pipe"),
-            Error::KillFailed(_) => write!(f, "Failed to terminate subprocess"),
-            Error::HandshakeFailure(err) => write!(f, "Failed to start subprocess: {err}"),
-            Error::Crashed => write!(f, "Child process crashed"),
+            Error::Timeout(duration) => write!(f, "Timed out after {duration:?}"),
+            Error::Panic(message) => write!(f, "Panic: {message}"),
+            Error::HandshakeFailure(message) => write!(f, "Failed to start subprocess: {message}"),
+            Error::Crashed => write!(f, "Subprocess crashed"),
             Error::Interrupted => write!(f, "Interrupted"),
             Error::Disconnected => write!(f, "Disconnected"),
+
+            Error::InitFailure(_) => write!(f, "Failed to start subprocess"),
+            Error::ReadFailed(_) => write!(f, "Failed to read from subprocess"),
+            Error::WriteFailed(_) => write!(f, "Failed to write to subprocess"),
+            Error::CreatePipeFailed(_) => write!(f, "Failed to create pipe"),
+            Error::KillFailed(_) => write!(f, "Failed to terminate subprocess"),
+            Error::SerializeFailed(_) => write!(f, "Failed to serialize message"),
+            Error::DeserializeFailed(_) => write!(f, "Failed to deserialize message"),
         }
-    }
-}
-
-impl From<bincode::Error> for Error {
-    fn from(err: bincode::Error) -> Self {
-        Error::Bincode(err)
-    }
-}
-
-impl From<RecvError> for Error {
-    fn from(err: RecvError) -> Self {
-        Error::Recv(err)
     }
 }
 
@@ -89,7 +72,7 @@ impl From<ErrorResponse> for Error {
 
 impl From<Error> for IoError {
     fn from(err: Error) -> IoError {
-        IoError::new(std::io::ErrorKind::Other, format!("{}", err))
+        IoError::new(std::io::ErrorKind::Other, err)
     }
 }
 
@@ -101,14 +84,13 @@ pub(crate) enum ErrorResponse {
 impl StdError for Error {
     fn source(&self) -> Option<&(dyn StdError + 'static)> {
         match self {
-            Error::Io(error) => Some(error),
-            Error::Recv(error) => Some(error),
-            Error::Bincode(error) => Some(error),
             Error::InitFailure(error) => Some(error),
             Error::ReadFailed(error) => Some(error),
             Error::WriteFailed(error) => Some(error),
             Error::CreatePipeFailed(error) => Some(error),
             Error::KillFailed(error) => Some(error),
+            Error::SerializeFailed(error) => Some(error),
+            Error::DeserializeFailed(error) => Some(error),
             _ => None,
         }
     }

--- a/sandbox/src/error.rs
+++ b/sandbox/src/error.rs
@@ -12,12 +12,10 @@ use std::time::Duration;
 #[derive(Debug)]
 #[non_exhaustive]
 pub enum Error {
+    /// Panic
+    Panic(PanicInfo),
     /// Timed out after {0:?}
     Timeout(Duration),
-    /// Panic: {0}
-    Panic(String),
-    /// When starting the child process fails
-    HandshakeFailure(String),
     /// Child process crashed
     Crashed,
     /// Interrupted (Ctrl+C)
@@ -25,6 +23,8 @@ pub enum Error {
     /// Read channel disconnected (other end hung up)
     Disconnected,
 
+    /// When starting the child process fails
+    HandshakeFailure(SerializableError),
     /// Failed to start child process
     InitFailure(IoError),
     /// Failed to read from child
@@ -42,15 +42,17 @@ pub enum Error {
 }
 
 impl fmt::Display for Error {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {
+            Error::Panic(panic_info) => write!(f, "{}", panic_info),
             Error::Timeout(duration) => write!(f, "Timed out after {duration:?}"),
-            Error::Panic(message) => write!(f, "Panic: {message}"),
-            Error::HandshakeFailure(message) => write!(f, "Failed to start subprocess: {message}"),
             Error::Crashed => write!(f, "Subprocess crashed"),
             Error::Interrupted => write!(f, "Interrupted"),
             Error::Disconnected => write!(f, "Disconnected"),
 
+            Error::HandshakeFailure(_) => {
+                write!(f, "Failed to start communicating with subprocess")
+            }
             Error::InitFailure(_) => write!(f, "Failed to start subprocess"),
             Error::ReadFailed(_) => write!(f, "Failed to read from subprocess"),
             Error::WriteFailed(_) => write!(f, "Failed to write to subprocess"),
@@ -76,14 +78,10 @@ impl From<Error> for IoError {
     }
 }
 
-#[derive(Serialize, Deserialize)]
-pub(crate) enum ErrorResponse {
-    Panic(String),
-}
-
 impl StdError for Error {
     fn source(&self) -> Option<&(dyn StdError + 'static)> {
         match self {
+            Error::HandshakeFailure(error) => Some(error),
             Error::InitFailure(error) => Some(error),
             Error::ReadFailed(error) => Some(error),
             Error::WriteFailed(error) => Some(error),
@@ -97,5 +95,93 @@ impl StdError for Error {
 
     fn cause(&self) -> Option<&dyn StdError> {
         self.source()
+    }
+}
+
+#[derive(Serialize, Deserialize)]
+pub struct SerializableError {
+    display: String,
+    debug: String,
+    source: Option<Box<SerializableError>>,
+}
+
+impl fmt::Display for SerializableError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{}", self.display)
+    }
+}
+
+impl fmt::Debug for SerializableError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{}", self.debug)
+    }
+}
+
+impl StdError for SerializableError {
+    fn source(&self) -> Option<&(dyn StdError + 'static)> {
+        if let Some(ref source) = self.source {
+            Some(source)
+        } else {
+            None
+        }
+    }
+}
+
+impl SerializableError {
+    pub fn new<E>(error: E) -> Self
+    where
+        E: StdError,
+    {
+        SerializableError {
+            display: format!("{}", error),
+            debug: format!("{:?}", error),
+            source: if let Some(source) = error.source() {
+                Some(Box::new(SerializableError::new(source)))
+            } else {
+                None
+            },
+        }
+    }
+}
+
+#[derive(Serialize, Deserialize, Clone, Debug)]
+pub(crate) enum ErrorResponse {
+    Panic(PanicInfo),
+}
+
+#[derive(Serialize, Deserialize, Clone, Debug)]
+pub struct PanicInfo {
+    pub(crate) message: Option<String>,
+    pub(crate) location: Option<LocationInfo>,
+    pub(crate) backtrace: Option<String>,
+}
+
+#[derive(Serialize, Deserialize, Clone, Debug)]
+pub struct LocationInfo {
+    pub(crate) file: String,
+    pub(crate) line: u32,
+}
+
+const BACKTRACE_OMITTED: &'static str = "
+
+Backtrace omitted.
+Run with RUST_BACKTRACE=1 environment variable to display it.
+Run with RUST_BACKTRACE=full to include source snippets.";
+
+impl fmt::Display for PanicInfo {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "The subprocess panicked (crashed).")?;
+        if let Some(ref message) = self.message {
+            write!(f, "\nMessage: {}", message)?;
+        }
+        if let Some(ref location) = self.location {
+            write!(f, "\nLocation: {}:{}", location.file, location.line)?;
+        }
+        if let Some(ref backtrace) = self.backtrace {
+            write!(f, "\n\nBacktrace:\n{backtrace}")?;
+        } else {
+            write!(f, "{BACKTRACE_OMITTED}")?;
+        }
+        Ok(())
     }
 }

--- a/sandbox/src/frame.rs
+++ b/sandbox/src/frame.rs
@@ -27,7 +27,7 @@ impl Frame {
         self.buf.resize(len as usize, 0);
         Read::read_exact(reader, &mut self.buf).map_err(Error::ReadFailed)?;
 
-        let value = bincode::deserialize(&self.buf)?;
+        let value = bincode::deserialize(&self.buf).map_err(Error::DeserializeFailed)?;
 
         Ok(value)
     }
@@ -37,7 +37,7 @@ impl Frame {
         W: Write,
         V: Serialize,
     {
-        let bytes = bincode::serialize(value)?;
+        let bytes = bincode::serialize(value).map_err(Error::SerializeFailed)?;
         let len = u32::to_ne_bytes(bytes.len() as u32);
         writer.write_all(&len).map_err(Error::WriteFailed)?;
         writer.write_all(&bytes).map_err(Error::WriteFailed)?;

--- a/sandbox/src/sandbox.rs
+++ b/sandbox/src/sandbox.rs
@@ -75,8 +75,8 @@ where
             .expect("Couldn't find executable");
         let args = S::args(&self.config);
 
-        let (child_reader, mut parent_writer) = std::io::pipe()?;
-        let (mut parent_reader, child_writer) = std::io::pipe()?;
+        let (child_reader, mut parent_writer) = std::io::pipe().map_err(Error::CreatePipeFailed)?;
+        let (mut parent_reader, child_writer) = std::io::pipe().map_err(Error::CreatePipeFailed)?;
 
         let process = ChildGuard(
             std::process::Command::new(program)
@@ -108,7 +108,7 @@ where
     /// Kills the child process
     pub fn stop(&mut self) -> Result<(), Error> {
         if let Some(mut worker) = self.worker.take() {
-            worker.process.kill()?;
+            worker.process.kill().map_err(Error::KillFailed)?;
             let _ = worker.reader_thread.join();
         }
         Ok(())

--- a/sandbox/src/service.rs
+++ b/sandbox/src/service.rs
@@ -5,7 +5,8 @@ use std::panic::RefUnwindSafe;
 use std::path::PathBuf;
 use std::time::Duration;
 
-use crate::{error::ErrorResponse, response::Response};
+use crate::error::{ErrorResponse, SerializableError};
+use crate::response::Response;
 
 /// In order to sandbox some logic, there needs to be an implementation
 /// of this trait for it.
@@ -41,4 +42,4 @@ pub trait Service: Sized + RefUnwindSafe + 'static {
 pub(crate) type MessageRequest<S> = <S as Service>::Req;
 pub(crate) type MessageResponse<S> = Response<Result<<S as Service>::Res, ErrorResponse>>;
 pub(crate) type HandshakeRequest<S> = <S as Service>::Config;
-pub(crate) type HandshakeResponse = Response<Result<(), String>>;
+pub(crate) type HandshakeResponse = Response<Result<(), SerializableError>>;


### PR DESCRIPTION
Removes `thiserror`, `byteorder`, and `color-eyre`. Now, `rink-sandbox` only depends on bincode, serde, and ctrlc, which is nice.

I also cleaned up some of the error handling in rink-sandbox.

I tried to add an integration test to cover the panic handler changes, but the test broke code coverage with invalid profraw files. There are also some existing tests covering these code paths, but code coverage information isn't saved when the process panics, exits, or is terminated. So the code coverage % on this PR is lower than it should be.

Binary size diff on linux:
```
Before : 3 952 528 bytes
After  : 3 568 592 bytes
Change :   383 936 bytes (9.71% smaller)
```

TODO:

- [x] Try to rewrite the test as a  rink-sandbox integration test, instead of a rink-cli test
- [x] Investigate the profraw corruption issue some more
- [x] Figure out if other stuff can be tested besides the panic handler