### PR TITLE
Escape expressions before putting into link in webapp

### DIFF
--- a/web/repl/src/index.ts
+++ b/web/repl/src/index.ts
@@ -227,7 +227,7 @@ Promise.all([wasmBlob, currency]).then(([buffer, currencyDataRes]) => {
 		let quote = document.createElement("blockquote");
 		quote.innerText = queryString;
 		let permalink = document.createElement("a");
-		permalink.href = `${location.origin}/?q=${queryString}`;
+		permalink.href = `${location.origin}/?q=${encodeURIComponent(queryString)}`;
 		permalink.text = "#";
 		quote.appendChild(permalink);
 		rinkDiv.appendChild(quote);


### PR DESCRIPTION
As per discussion #232, the expressions should probably be escaped before they're used as an HTTP URL.