### PR TITLE
handle some more unicode operators, and numerical exponents

### DIFF
--- a/core/src/loader/gnu_units.rs
+++ b/core/src/loader/gnu_units.rs
@@ -211,7 +211,7 @@ fn parse_term(iter: &mut Iter<'_>) -> Expr {
             }
             _ => Expr::new_unit(name),
         },
-        Token::Number(num, frac, exp) => crate::types::Number::from_parts(
+        Token::Number(num, frac, exp) => Numeric::from_parts(
             &*num,
             frac.as_ref().map(|x| &**x),
             exp.as_ref().map(|x| &**x),

--- a/core/src/parsing/text_query.rs
+++ b/core/src/parsing/text_query.rs
@@ -80,12 +80,14 @@ fn describe(token: &Token) -> String {
     }
 }
 
+// The underlying character iterator plus an optional future token to
+// produce.
 #[derive(Clone)]
-pub struct TokenIterator<'a>(Peekable<Chars<'a>>);
+pub struct TokenIterator<'a>(Peekable<Chars<'a>>, Option<Token>);
 
 impl<'a> TokenIterator<'a> {
     pub fn new(input: &'a str) -> TokenIterator<'a> {
-        TokenIterator(input.chars().peekable())
+        TokenIterator(input.chars().peekable(), None)
     }
 }
 
@@ -102,10 +104,36 @@ fn is_currency(ch: char) -> bool {
     }
 }
 
+fn is_superscript(ch: char) -> bool {
+    match ch {
+        '⁰' | '¹' | '²' | '³' | '⁴' | '⁵' | '⁶' | '⁷' | '⁸' | '⁹' => true,
+        _ => false,
+    }
+}
+
+fn digit_from_superscript(sup: char) -> Option<char> {
+    match sup {
+        '⁰' => Some('0'),
+        '¹' => Some('1'),
+        '²' => Some('2'),
+        '³' => Some('3'),
+        '⁴' => Some('4'),
+        '⁵' => Some('5'),
+        '⁶' => Some('6'),
+        '⁷' => Some('7'),
+        '⁸' => Some('8'),
+        '⁹' => Some('9'),
+        _ => None,
+    }
+}
+
 impl<'a> Iterator for TokenIterator<'a> {
     type Item = Token;
 
     fn next(&mut self) -> Option<Token> {
+        if self.1.is_some() {
+            return self.1.take();
+        }
         if self.0.peek().is_none() {
             return Some(Token::Eof);
         }
@@ -122,7 +150,7 @@ impl<'a> Iterator for TokenIterator<'a> {
             ',' => Token::Comma,
             // U+2215 ∕ DIVISION SLASH
             // Used by rink-web to render these tight fractions.
-            '|' | '\u{2215}' => Token::Pipe,
+            '|' | '\u{2044}' | '\u{2215}' => Token::Pipe,
             ':' => Token::Colon,
             '→' => Token::DashArrow,
             '<' if self.0.peek().cloned() == Some('<') => {
@@ -141,6 +169,7 @@ impl<'a> Iterator for TokenIterator<'a> {
                     Token::Asterisk
                 }
             }
+            '⋅' | '×' => Token::Asterisk,
             '-' => match self.0.peek().cloned() {
                 Some('>') => {
                     self.0.next();
@@ -149,6 +178,7 @@ impl<'a> Iterator for TokenIterator<'a> {
                 _ => Token::Minus,
             },
             '\u{2212}' => Token::Minus,
+            '÷' => Token::Slash,
             '/' => match self.0.peek() {
                 Some(&'/') => loop {
                     match self.0.next() {
@@ -315,6 +345,28 @@ impl<'a> Iterator for TokenIterator<'a> {
                     exp = Some(buf)
                 }
                 Token::Decimal(integer, frac, exp)
+            }
+            x @ '⁰'
+            | x @ '¹'
+            | x @ '²'
+            | x @ '³'
+            | x @ '⁴'
+            | x @ '⁵'
+            | x @ '⁶'
+            | x @ '⁷'
+            | x @ '⁸'
+            | x @ '⁹' => {
+                let mut integer = String::new();
+                integer.push(digit_from_superscript(x).unwrap());
+                while let Some(c) = self.0.peek().cloned() {
+                    if is_superscript(c) {
+                        integer.push(digit_from_superscript(self.0.next().unwrap()).unwrap());
+                    } else {
+                        break;
+                    }
+                }
+                self.1 = Some(Token::Decimal(integer, None, None));
+                Token::Caret
             }
             '\\' => match self.0.next() {
                 Some('u') => {
@@ -960,6 +1012,25 @@ mod test {
     #[test]
     fn sub_crash_regression() {
         assert_eq!(parse("-"), "-<error: Expected term, got eof>");
+    }
+
+    #[test]
+    fn multiplication() {
+        assert_eq!(parse("a⋅b"), parse("a*b"));
+        assert_eq!(parse("a×b"), parse("a*b"));
+    }
+
+    #[test]
+    fn division() {
+        assert_eq!(parse("2|3"), parse("2/3"));
+        assert_eq!(parse("2∕3"), parse("2/3"));
+        assert_eq!(parse("2÷3"), parse("2/3"));
+        assert_eq!(parse("2⁄3"), parse("2/3"));
+    }
+
+    #[test]
+    fn exponents() {
+        assert_eq!(parse("2¹³⁶²⁷⁹⁸⁴¹−1"), parse("2^136279841−1"));
     }
 
     #[test]

--- a/core/src/parsing/text_query.rs
+++ b/core/src/parsing/text_query.rs
@@ -82,8 +82,6 @@ fn describe(token: &Token) -> String {
     }
 }
 
-// The underlying character iterator plus an optional future token to
-// produce.
 #[derive(Clone)]
 pub struct TokenIterator<'a>(Peekable<Chars<'a>>);
 

--- a/core/src/parsing/text_query.rs
+++ b/core/src/parsing/text_query.rs
@@ -14,6 +14,7 @@ pub enum Token {
     Comment(usize),
     Ident(String),
     Decimal(String, Option<String>, Option<String>),
+    Exponent(String),
     Hex(String),
     Oct(String),
     Bin(String),
@@ -49,6 +50,7 @@ fn describe(token: &Token) -> String {
         Token::Newline | Token::Comment(_) => "\\n".to_owned(),
         Token::Ident(_) => "ident".to_owned(),
         Token::Decimal(_, _, _) => "number".to_owned(),
+        Token::Exponent(_) => "exponent".to_owned(),
         Token::Hex(_) => "hex".to_owned(),
         Token::Oct(_) => "octal".to_owned(),
         Token::Bin(_) => "binary".to_owned(),
@@ -83,11 +85,11 @@ fn describe(token: &Token) -> String {
 // The underlying character iterator plus an optional future token to
 // produce.
 #[derive(Clone)]
-pub struct TokenIterator<'a>(Peekable<Chars<'a>>, Option<Token>);
+pub struct TokenIterator<'a>(Peekable<Chars<'a>>);
 
 impl<'a> TokenIterator<'a> {
     pub fn new(input: &'a str) -> TokenIterator<'a> {
-        TokenIterator(input.chars().peekable(), None)
+        TokenIterator(input.chars().peekable())
     }
 }
 
@@ -100,13 +102,6 @@ fn is_currency(ch: char) -> bool {
         | '₭' | '₮' | '₯' | '₰' | '₱' | '₲' | '₳' | '₴' | '₵' | '₶' | '₷' | '₸' | '₹' | '₺'
         | '₻' | '₼' | '₽' | '₾' | '₿' | '⃀' | '꠸' | '﷼' | '﹩' | '＄' | '￠' | '￡' | '￥'
         | '￦' | '𑿝' | '𑿞' | '𑿟' | '𑿠' | '𞋿' | '𞲰' => true,
-        _ => false,
-    }
-}
-
-fn is_superscript(ch: char) -> bool {
-    match ch {
-        '⁰' | '¹' | '²' | '³' | '⁴' | '⁵' | '⁶' | '⁷' | '⁸' | '⁹' => true,
         _ => false,
     }
 }
@@ -131,9 +126,6 @@ impl<'a> Iterator for TokenIterator<'a> {
     type Item = Token;
 
     fn next(&mut self) -> Option<Token> {
-        if self.1.is_some() {
-            return self.1.take();
-        }
         if self.0.peek().is_none() {
             return Some(Token::Eof);
         }
@@ -346,27 +338,18 @@ impl<'a> Iterator for TokenIterator<'a> {
                 }
                 Token::Decimal(integer, frac, exp)
             }
-            x @ '⁰'
-            | x @ '¹'
-            | x @ '²'
-            | x @ '³'
-            | x @ '⁴'
-            | x @ '⁵'
-            | x @ '⁶'
-            | x @ '⁷'
-            | x @ '⁸'
-            | x @ '⁹' => {
+            x if digit_from_superscript(x).is_some() => {
                 let mut integer = String::new();
                 integer.push(digit_from_superscript(x).unwrap());
                 while let Some(c) = self.0.peek().cloned() {
-                    if is_superscript(c) {
-                        integer.push(digit_from_superscript(self.0.next().unwrap()).unwrap());
+                    if let Some(digit) = digit_from_superscript(c) {
+                        self.0.next();
+                        integer.push(digit);
                     } else {
                         break;
                     }
                 }
-                self.1 = Some(Token::Decimal(integer, None, None));
-                Token::Caret
+                Token::Exponent(integer)
             }
             '\\' => match self.0.next() {
                 Some('u') => {
@@ -500,7 +483,11 @@ impl<'a> Iterator for TokenIterator<'a> {
                 let mut prev = x;
                 buf.push(x);
                 while let Some(c) = self.0.peek().cloned() {
-                    if is_superscript(c) || (c.is_digit(10) && is_currency(prev)) {
+                    if digit_from_superscript(c).is_some() {
+                        // split x² into Ident(x) + Exponent(2)
+                        break;
+                    } else if c.is_digit(10) && is_currency(prev) {
+                        // split $10 into Ident($) + Decimal(10)
                         break;
                     } else if c.is_alphanumeric() || c == '_' || c == '$' {
                         prev = self.0.next().unwrap();
@@ -667,6 +654,12 @@ fn parse_pow(iter: &mut Iter<'_>) -> Expr {
             iter.next();
             let right = parse_pow(iter);
             Expr::new_pow(left, right)
+        }
+        Token::Exponent(ref exp_str) => {
+            let res = crate::types::Number::from_parts(&exp_str, None, None);
+            let exp = res.map(Expr::new_const).unwrap_or_else(Expr::new_error);
+            iter.next();
+            Expr::new_pow(left, exp)
         }
         _ => left,
     }

--- a/core/src/parsing/text_query.rs
+++ b/core/src/parsing/text_query.rs
@@ -105,6 +105,7 @@ fn is_currency(ch: char) -> bool {
 }
 
 fn digit_from_superscript(sup: char) -> Option<char> {
+    // From the Unicode "Superscripts and Subscripts" block, U+2070 to U+209F
     match sup {
         '⁰' => Some('0'),
         '¹' => Some('1'),
@@ -138,8 +139,8 @@ impl<'a> Iterator for TokenIterator<'a> {
             '=' => Token::Equals,
             '^' => Token::Caret,
             ',' => Token::Comma,
-            // U+2215 ∕ DIVISION SLASH
-            // Used by rink-web to render these tight fractions.
+            // U+2044 fraction slash '⁄'
+            // U+2215 division slash '∕'
             '|' | '\u{2044}' | '\u{2215}' => Token::Pipe,
             ':' => Token::Colon,
             '→' => Token::DashArrow,
@@ -159,6 +160,8 @@ impl<'a> Iterator for TokenIterator<'a> {
                     Token::Asterisk
                 }
             }
+            // U+22C5 dot operator '⋅'
+            // U+00D7 multiplication sign '×'
             '⋅' | '×' => Token::Asterisk,
             '-' => match self.0.peek().cloned() {
                 Some('>') => {
@@ -167,7 +170,9 @@ impl<'a> Iterator for TokenIterator<'a> {
                 }
                 _ => Token::Minus,
             },
+            // U+2212 minus sign '−'
             '\u{2212}' => Token::Minus,
+            // U+00F7 division sign '÷'
             '÷' => Token::Slash,
             '/' => match self.0.peek() {
                 Some(&'/') => loop {
@@ -321,6 +326,7 @@ impl<'a> Iterator for TokenIterator<'a> {
                     while let Some(c) = self.0.peek().cloned() {
                         match c {
                             '0'..='9' => buf.push(self.0.next().unwrap()),
+                            // U+2009 thin space ' '
                             '\u{2009}' | '_' => {
                                 self.0.next();
                             }

--- a/core/src/parsing/text_query.rs
+++ b/core/src/parsing/text_query.rs
@@ -500,7 +500,7 @@ impl<'a> Iterator for TokenIterator<'a> {
                 let mut prev = x;
                 buf.push(x);
                 while let Some(c) = self.0.peek().cloned() {
-                    if c.is_digit(10) && is_currency(prev) {
+                    if is_superscript(c) || (c.is_digit(10) && is_currency(prev)) {
                         break;
                     } else if c.is_alphanumeric() || c == '_' || c == '$' {
                         prev = self.0.next().unwrap();
@@ -1031,6 +1031,10 @@ mod test {
     #[test]
     fn exponents() {
         assert_eq!(parse("2¹³⁶²⁷⁹⁸⁴¹−1"), parse("2^136279841−1"));
+        assert_eq!(parse("e³"), parse("e^3"));
+        assert_eq!(parse("1m/s²"), parse("1m/s^2"));
+        assert_eq!(parse("1kg*m²/s²"), parse("1kg*m^2/s^2"));
+        assert_eq!(parse("1V/m²"), parse("1V/m^2"));
     }
 
     #[test]

--- a/core/src/parsing/text_query.rs
+++ b/core/src/parsing/text_query.rs
@@ -608,7 +608,7 @@ fn parse_term(iter: &mut Iter<'_>) -> Expr {
             }
         }
         Token::Quote(string) => Expr::Quote { string },
-        Token::Decimal(num, frac, exp) => crate::types::Number::from_parts(
+        Token::Decimal(num, frac, exp) => Numeric::from_parts(
             &*num,
             frac.as_ref().map(|x| &**x),
             exp.as_ref().map(|x| &**x),
@@ -656,7 +656,7 @@ fn parse_pow(iter: &mut Iter<'_>) -> Expr {
             Expr::new_pow(left, right)
         }
         Token::Exponent(ref exp_str) => {
-            let res = crate::types::Number::from_parts(&exp_str, None, None);
+            let res = Numeric::from_parts(&exp_str, None, None);
             let exp = res.map(Expr::new_const).unwrap_or_else(Expr::new_error);
             iter.next();
             Expr::new_pow(left, exp)
@@ -1028,6 +1028,8 @@ mod test {
         assert_eq!(parse("1m/s²"), parse("1m/s^2"));
         assert_eq!(parse("1kg*m²/s²"), parse("1kg*m^2/s^2"));
         assert_eq!(parse("1V/m²"), parse("1V/m^2"));
+        assert_eq!(parse("x¹²³⁴⁵⁶⁷⁸⁹⁰"), parse("x^1234567890"));
+        assert_eq!(parse("¹"), "<error: Expected term, got exponent>");
     }
 
     #[test]

--- a/core/src/types/number.rs
+++ b/core/src/types/number.rs
@@ -6,7 +6,7 @@ use super::{BaseUnit, Dimensionality};
 use crate::loader::Context;
 use crate::output::{Digits, NumberParts};
 use crate::runtime::Show;
-use crate::types::{BigInt, BigRat, Numeric};
+use crate::types::{BigInt, Numeric};
 use serde_derive::{Deserialize, Serialize};
 use std::fmt;
 use std::ops::{Add, Div, Mul, Neg, Sub};
@@ -54,40 +54,6 @@ impl Number {
     pub fn new_unit(num: Numeric, unit: BaseUnit) -> Number {
         let unit = Dimensionality::base_unit(unit);
         Number { value: num, unit }
-    }
-
-    pub fn from_parts(
-        integer: &str,
-        frac: Option<&str>,
-        exp: Option<&str>,
-    ) -> Result<Numeric, String> {
-        use std::str::FromStr;
-
-        let num = BigInt::from_str_radix(integer, 10).unwrap();
-        let frac = if let Some(frac) = frac {
-            let frac_digits = frac.len();
-            let frac = BigInt::from_str_radix(frac, 10).unwrap();
-            BigRat::ratio(&frac, &BigInt::from(10u64).pow(frac_digits as u32))
-        } else {
-            BigRat::zero()
-        };
-        let exp = if let Some(exp) = exp {
-            let exp: i32 = match FromStr::from_str(exp) {
-                Ok(exp) => exp,
-                // presumably because it is too large
-                Err(e) => return Err(format!("Failed to parse exponent: {}", e)),
-            };
-            let res = BigInt::from(10u64).pow(exp.abs() as u32);
-            if exp < 0 {
-                BigRat::ratio(&BigInt::one(), &res)
-            } else {
-                BigRat::ratio(&res, &BigInt::one())
-            }
-        } else {
-            BigRat::one()
-        };
-        let num = &BigRat::ratio(&num, &BigInt::one()) + &frac;
-        Ok(Numeric::Rational(&num * &exp))
     }
 
     /// Computes the reciprocal (1/x) of the value.

--- a/core/src/types/numeric.rs
+++ b/core/src/types/numeric.rs
@@ -116,6 +116,40 @@ impl Numeric {
         self.into()
     }
 
+    pub fn from_parts(
+        integer: &str,
+        frac: Option<&str>,
+        exp: Option<&str>,
+    ) -> Result<Numeric, String> {
+        use std::str::FromStr;
+
+        let num = BigInt::from_str_radix(integer, 10).unwrap();
+        let frac = if let Some(frac) = frac {
+            let frac_digits = frac.len();
+            let frac = BigInt::from_str_radix(frac, 10).unwrap();
+            BigRat::ratio(&frac, &BigInt::from(10u64).pow(frac_digits as u32))
+        } else {
+            BigRat::zero()
+        };
+        let exp = if let Some(exp) = exp {
+            let exp: i32 = match FromStr::from_str(exp) {
+                Ok(exp) => exp,
+                // presumably because it is too large
+                Err(e) => return Err(format!("Failed to parse exponent: {}", e)),
+            };
+            let res = BigInt::from(10u64).pow(exp.abs() as u32);
+            if exp < 0 {
+                BigRat::ratio(&BigInt::one(), &res)
+            } else {
+                BigRat::ratio(&res, &BigInt::one())
+            }
+        } else {
+            BigRat::one()
+        };
+        let num = &BigRat::ratio(&num, &BigInt::one()) + &frac;
+        Ok(Numeric::Rational(&num * &exp))
+    }
+
     /// Returns (is_exact, repr).
     pub fn to_string(&self, base: u8, digits: Digits) -> (bool, String) {
         use std::num::FpCategory;


### PR DESCRIPTION
Specifically, handle ‘⋅’ and ‘×’ as multiplication and ‘⁄’ (U+2044 FRACTION SLASH) and ‘÷’ as division.

Superscripted numbers are turned into into a two–token sequence with an asterisk and the corresponding decimal number, so ‘2³’ becomes Token::Decimal('2') Token::Asterisk Token::Decimal('3').