### PR TITLE
QueryError now implements std::error:Error

### DIFF
--- a/core/src/output/reply.rs
+++ b/core/src/output/reply.rs
@@ -171,6 +171,8 @@ pub enum QueryError {
     Generic { message: String },
 }
 
+impl std::error::Error for QueryError {}
+
 impl QueryError {
     pub fn generic(message: String) -> QueryError {
         QueryError::Generic { message }


### PR DESCRIPTION
for the obvious reasons.

Fixes #238